### PR TITLE
Remove plugin engine ranges from marketplace listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ installation refreshes.
    git repository (with an optional `subdir` for multi-plugin repositories)
    or your npm package.
 3. Open a pull request. CI validates the entry; a maintainer reviews the
-   plugin itself — source, behavior, and requested engine ranges.
+   plugin itself, including its source and behavior.
 
 Approval covers the listing. With a semver `range` source you release
 updates by tagging your own repository; changing the entry itself (source
-location, name, branding, wider ranges) needs a new reviewed pull request.
+location, name, or branding) needs a new reviewed pull request.
 The account that opens the listing pull request is recorded as the owner in
 `author.github` and gates later entry changes.
 

--- a/entries/prompt-shaper.json
+++ b/entries/prompt-shaper.json
@@ -5,7 +5,6 @@
   "icon": "AiContentGenerator01",
   "tags": ["agent-interaction", "prompts"],
   "author": { "name": "BB Team", "github": "get-bb", "url": "https://getbb.app" },
-  "engines": { "bb": ">=0.0.34", "bbPluginSdk": "^0.5.0" },
   "source": {
     "git": {
       "url": "https://github.com/brsbl/bb-plugins.git",

--- a/entries/slopcop.json
+++ b/entries/slopcop.json
@@ -14,10 +14,6 @@
     "name": "Sawyer Hood",
     "github": "SawyerHood"
   },
-  "engines": {
-    "bb": ">=0.35",
-    "bbPluginSdk": ">=0.4.4"
-  },
   "source": {
     "git": {
       "url": "https://github.com/SawyerHood/bb-slop-cop.git",

--- a/entries/thread-hover-cards.json
+++ b/entries/thread-hover-cards.json
@@ -5,7 +5,6 @@
   "icon": "ZoomIn",
   "tags": ["interface", "threads", "sidebar"],
   "author": { "name": "BB Team", "github": "get-bb", "url": "https://getbb.app" },
-  "engines": { "bb": ">=0.0.34", "bbPluginSdk": "^0.5.0" },
   "source": {
     "git": {
       "url": "https://github.com/brsbl/bb-plugins.git",

--- a/schema/marketplace.schema.json
+++ b/schema/marketplace.schema.json
@@ -95,15 +95,6 @@
             "url": { "type": "string", "pattern": "^https://" }
           }
         },
-        "engines": {
-          "type": "object",
-          "additionalProperties": false,
-          "$comment": "May narrow the plugin manifest's ranges; BB refuses an install that widens them.",
-          "properties": {
-            "bb": { "type": "string", "minLength": 1 },
-            "bbPluginSdk": { "type": "string", "minLength": 1 }
-          }
-        },
         "source": {
           "oneOf": [
             { "$ref": "#/$defs/npmSource" },


### PR DESCRIPTION
## Summary

- remove stale `engines` fields from all marketplace entries
- remove `engines` from the marketplace schema
- update submission guidance to match package-owned compatibility checks

## Tests

- `npm run build`
- `npm run check`

> AGENT GENERATED: by GPT-5