### PR TITLE
Add plugin entry: cascade

### DIFF
--- a/entries/cascade.json
+++ b/entries/cascade.json
@@ -1,0 +1,19 @@
+{
+  "id": "cascade",
+  "displayName": "Cascade",
+  "description": "Shows active BB threads in a tiled layout with horizontal columns and vertical groups.",
+  "icon": {
+    "url": "./icons/cascade-3a4890b8.svg"
+  },
+  "tags": ["interface", "threads", "workspace"],
+  "author": {
+    "name": "Sawyer Hood",
+    "github": "SawyerHood"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/SawyerHood/bb-plugin-cascade.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/icons/cascade-3a4890b8.svg
+++ b/icons/cascade-3a4890b8.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+     stroke="#000" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Four artboards of unequal width in two rows — the strip itself: rows of
+       columns, each column a board. Outline style to match BB's stroked icon
+       set (1.75 at a 24 viewBox). BB renders plugin icons as CSS masks, which
+       key off alpha coverage, so the stroke is deliberately an opaque literal
+       rather than currentColor — currentColor has no inherited context inside
+       a mask source and would not be guaranteed to resolve. -->
+  <rect x="2.75" y="3.75" width="8.25" height="7" rx="1.5"/>
+  <rect x="13.5" y="3.75" width="7.75" height="7" rx="1.5"/>
+  <rect x="2.75" y="13.25" width="6" height="7" rx="1.5"/>
+  <rect x="10.75" y="13.25" width="10.5" height="7" rx="1.5"/>
+</svg>


### PR DESCRIPTION
## What it does

Cascade shows active BB threads in a tiled layout. Users can move across columns and switch between vertical groups.

## Release

The entry tracks `^0.1.0` from `SawyerHood/bb-plugin-cascade`.

## Checks

- `npm run typecheck`
- `bb plugin build` with only production dependencies
- Marketplace `npm run build`
- Marketplace `npm run check`

## Security

The plugin uses the BB SDK to read thread indexes and change threads. It does not use an external service.

> AGENT GENERATED: by GPT-5
