### PR TITLE
Add plugin entry: t3sidebar

### DIFF
--- a/entries/t3sidebar.json
+++ b/entries/t3sidebar.json
@@ -1,0 +1,17 @@
+{
+  "id": "t3sidebar",
+  "displayName": "T3 Sidebar",
+  "description": "Replaces the BB thread list with a stable inbox, snooze controls, and child thread links.",
+  "icon": "PanelLeft",
+  "tags": ["interface", "sidebar", "threads"],
+  "author": {
+    "name": "Sawyer Hood",
+    "github": "SawyerHood"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/SawyerHood/bb-plugin-t3sidebar.git",
+      "range": "^0.1.0"
+    }
+  }
+}


### PR DESCRIPTION
## What it does

T3 Sidebar replaces the BB thread list with a stable inbox. It adds settled and snoozed thread states.

## Release

The entry tracks `^0.1.0` from `SawyerHood/bb-plugin-t3sidebar`.

## Checks

- `npm run typecheck`
- `npm test` with 80 tests
- `bb plugin build` with only production dependencies
- Marketplace `npm run build`
- Marketplace `npm run check`

## Security

The plugin stores settled and snoozed states in its BB plugin database. It does not use an external service.

> AGENT GENERATED: by GPT-5
