### PR TITLE
Slim Cascade marketplace icon

### DIFF
--- a/entries/cascade.json
+++ b/entries/cascade.json
@@ -3,7 +3,7 @@
   "displayName": "Cascade",
   "description": "Shows active BB threads in a tiled layout with horizontal columns and vertical groups.",
   "icon": {
-    "url": "./icons/cascade-3a4890b8.svg"
+    "url": "./icons/cascade-7b651515.svg"
   },
   "tags": ["interface", "threads", "workspace"],
   "author": {

--- a/icons/cascade-7b651515.svg
+++ b/icons/cascade-7b651515.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
-     stroke="#000" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+     stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
   <!-- Four artboards of unequal width in two rows — the strip itself: rows of
        columns, each column a board. Outline style to match BB's stroked icon
-       set (1.75 at a 24 viewBox). BB renders plugin icons as CSS masks, which
+       set (1.5 at a 24 viewBox). BB renders plugin icons as CSS masks, which
        key off alpha coverage, so the stroke is deliberately an opaque literal
        rather than currentColor — currentColor has no inherited context inside
        a mask source and would not be guaranteed to resolve. -->


### PR DESCRIPTION
## Change

This change reduces the Cascade icon stroke from `1.75` to `1.5`. The icon now matches the other marketplace icons.

## Checks

- Marketplace `npm run check`
- The icon hash matches its file name.

> AGENT GENERATED: by GPT-5
