### PR TITLE
Add plugin entry: usage-page

### DIFF
--- a/entries/usage-page.json
+++ b/entries/usage-page.json
@@ -1,17 +1,26 @@
 {
   "id": "usage-page",
   "displayName": "Usage",
-  "description": "Tracks coding-agent token usage and estimated API cost across enrolled machines.",
+  "description": "Tracks Claude Code, Codex, and Pi token usage with estimated API costs in a bb dashboard.",
   "icon": "ChartColumn",
-  "tags": ["analytics", "costs", "tokens", "usage"],
+  "tags": [
+    "usage",
+    "analytics",
+    "tokens",
+    "costs",
+    "claude-code",
+    "codex",
+    "pi"
+  ],
   "author": {
-    "name": "Mayank Bansal",
-    "github": "MayankBansal12"
+    "name": "Evan",
+    "github": "iamEvanYT",
+    "url": "https://github.com/iamEvanYT"
   },
   "source": {
     "git": {
-      "url": "https://github.com/MayankBansal12/bb-plugin-usage.git",
-      "range": "^0.3.1"
+      "url": "https://github.com/iamEvanYT/bb-usage-page.git",
+      "range": "^1.1.0"
     }
   }
 }

--- a/entries/usage-page.json
+++ b/entries/usage-page.json
@@ -1,6 +1,6 @@
 {
   "id": "usage-page",
-  "displayName": "Usage",
+  "displayName": "Usage Page",
   "description": "Tracks Claude Code, Codex, and Pi token usage with estimated API costs in a bb dashboard.",
   "icon": "ChartColumn",
   "tags": [
@@ -20,7 +20,7 @@
   "source": {
     "git": {
       "url": "https://github.com/iamEvanYT/bb-usage-page.git",
-      "range": "^1.1.0"
+      "range": "^1.2.0"
     }
   }
 }

--- a/entries/usage-page.json
+++ b/entries/usage-page.json
@@ -1,5 +1,5 @@
 {
-  "id": "usage",
+  "id": "usage-page",
   "displayName": "Usage",
   "description": "Tracks coding-agent token usage and estimated API cost across enrolled machines.",
   "icon": "ChartColumn",

--- a/entries/usage-page.json
+++ b/entries/usage-page.json
@@ -1,6 +1,6 @@
 {
   "id": "usage-page",
-  "displayName": "Usage Page",
+  "displayName": "Usage",
   "description": "Tracks Claude Code, Codex, and Pi token usage with estimated API costs in a bb dashboard.",
   "icon": "ChartColumn",
   "tags": [

--- a/entries/usage.json
+++ b/entries/usage.json
@@ -1,0 +1,17 @@
+{
+  "id": "usage",
+  "displayName": "Usage",
+  "description": "Tracks coding-agent token usage and estimated API cost across enrolled machines.",
+  "icon": "ChartColumn",
+  "tags": ["analytics", "costs", "tokens", "usage"],
+  "author": {
+    "name": "Mayank Bansal",
+    "github": "MayankBansal12"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/MayankBansal12/bb-plugin-usage.git",
+      "range": "^0.3.1"
+    }
+  }
+}


### PR DESCRIPTION
## What the plugin does

Usage adds a bb dashboard for Claude Code, Codex, and Pi token usage, with provider, project, model, and daily breakdowns plus estimated API-equivalent costs.

## Source release

- Package: `bb-plugin-usage-page`
- Plugin ID: `usage-page`
- Repository: https://github.com/iamEvanYT/bb-usage-page
- Release tag: `v1.2.0`
- Marketplace range: `^1.2.0`

## Plugin checks

- `npm ci --ignore-scripts`
- `npm run typecheck`
- `npm run build`

## Marketplace checks

- `npm ci --ignore-scripts`
- `npm run build`
- `npm run check`

## Permissions and external services

The plugin reads transcript files from the machine running the bb server and stores scan data under `~/.bb/plugins/usage/`. It does not require credentials. It may fetch the public LiteLLM model pricing JSON to estimate costs; transcript data is not sent to that service.
