### PR TITLE
Add plugin entry: pets

### DIFF
--- a/entries/pets.json
+++ b/entries/pets.json
@@ -1,0 +1,19 @@
+{
+  "id": "pets",
+  "displayName": "Pets",
+  "description": "Adds a pixel companion to the BB window that mirrors your fleet, walks to threads waiting on you, and earns XP from finished turns.",
+  "icon": {
+    "url": "./icons/pets-88a81ec9.svg"
+  },
+  "tags": ["companion", "interface", "pixel-art", "threads", "ai-art"],
+  "author": {
+    "name": "Vedran Burojevic",
+    "github": "vburojevic"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/vburojevic/bb-plugin-pets.git",
+      "range": "^0.2.0"
+    }
+  }
+}

--- a/icons/pets-88a81ec9.svg
+++ b/icons/pets-88a81ec9.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000">
+  <!-- Paw print: one pad and four toes, matching the plugin's own brand icon.
+       BB renders plugin icons as CSS masks, which key off alpha coverage, so
+       the fill is an opaque literal rather than currentColor — currentColor
+       has no inherited context inside a mask source. -->
+  <ellipse cx="12" cy="15.4" rx="4.6" ry="3.9"/>
+  <ellipse cx="6.1" cy="11.6" rx="1.9" ry="2.5" transform="rotate(-18 6.1 11.6)"/>
+  <ellipse cx="17.9" cy="11.6" rx="1.9" ry="2.5" transform="rotate(18 17.9 11.6)"/>
+  <ellipse cx="9.4" cy="7.6" rx="1.9" ry="2.6" transform="rotate(-8 9.4 7.6)"/>
+  <ellipse cx="14.6" cy="7.6" rx="1.9" ry="2.6" transform="rotate(8 14.6 7.6)"/>
+</svg>


### PR DESCRIPTION
## What the plugin does

Pets adds a pixel companion that lives along the bottom of the BB window and mirrors the agent fleet: it thinks while turns run, taps its foot when a thread is waiting on you, droops on failures, and sleeps when everything is quiet. When a thread needs attention it walks to that thread's sidebar row and points at it; clicking the pet then opens the thread. Work earns XP, which drives five evolution stages with regenerated artwork per stage.

Other surfaces: a Pets nav panel (Habitat / Den / Hatchery / Stats), a sidebar footer button that summons the pet's menu, an optional AI hatchery (describe a creature → drafts → a fully animated pet), an autonomy director with five personality toggles, and a first-run tour.

## Source release

- Repository: https://github.com/vburojevic/bb-plugin-pets (public, MIT)
- Release: `v0.2.0` (annotated tag → commit `9248e40`)
- Entry source: git semver `range: "^0.2.0"` at the repository root (single plugin, repository-wide `vX.Y.Z` tags, no `subdir`, no `tagPrefix`)

## Plugin checks

- `npx tsc --noEmit` — clean
- `npm test` — 63 tests, 63 pass (pixel pipeline: quantizers, atlas fallbacks, frame play-modes, line selection)
- `bb plugin build` — green; `dist/` is committed so a git install validates against prebuilt artifacts
- Installed and exercised live in BB (overlay, panel, generation jobs, CLI)

## Marketplace checks

- `npm ci --ignore-scripts` → `npm run build` → `npm run check` (liveness) all pass; `dist/marketplace.json` composes with 4 entries
- Entry id `pets` matches the filename and the id derived from the package name (`bb-plugin-pets` → `pets`)
- `author.github` is the account opening this PR
- Icon: `icons/pets-88a81ec9.svg`, 751 bytes, plain geometry with an opaque literal fill (no scripts, no remote references), content-hashed filename

## Permissions, external services, security

- **Optional API keys, never required.** The plugin ships a bundled starter pet and works fully offline-of-AI with no keys. Users may add their own OpenAI key (artwork) and Retro Diffusion key (animation) to hatch custom pets; keys are stored via BB's secret settings, never in the repository.
- **Network:** only `api.openai.com` and `api.retrodiffusion.ai`, and only during user-initiated generation jobs. No telemetry, no analytics, no other outbound calls.
- **Data:** a local SQLite database and generated PNGs under the plugin's own data directory. Thread titles and lifecycle events are read for pet reactions and stay on the machine.
- **Cost transparency:** every action that spends API credit shows an estimated cost in its tooltip or hint.
