### PR TITLE
Add plugin entry: ayu

### DIFF
--- a/entries/ayu.json
+++ b/entries/ayu.json
@@ -1,0 +1,26 @@
+{
+  "id": "ayu",
+  "displayName": "Ayu",
+  "description": "Adds the three ayu themes (Light, Dark and Mirage) and a settings panel that switches between them and copies any colour from the palette.",
+  "icon": {
+    "url": "./icons/ayu-9660fa88.svg"
+  },
+  "tags": [
+    "themes",
+    "appearance",
+    "colors",
+    "syntax-highlighting",
+    "interface",
+    "ayu"
+  ],
+  "author": {
+    "name": "Vedran Burojević",
+    "github": "vburojevic"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/vburojevic/bb-plugin-ayu.git",
+      "range": "^0.2.0"
+    }
+  }
+}

--- a/icons/ayu-9660fa88.svg
+++ b/icons/ayu-9660fa88.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000">
+  <!-- The plugin's own three-dot mark, scaled from its 16 viewBox to 24 to sit
+       with BB's icon set. Filled rather than stroked because the trio is the
+       plugin's brand mark. BB renders plugin icons as CSS masks, which key off
+       alpha coverage: there is deliberately no background plate (it would mask
+       to a solid square and erase the dots), and the fill is an opaque literal
+       rather than currentColor, which has no inherited context inside a mask
+       source and would not be guaranteed to resolve. -->
+  <circle cx="12" cy="6.9" r="4.35"/>
+  <circle cx="6.6" cy="16.35" r="4.35"/>
+  <circle cx="17.4" cy="16.35" r="4.35"/>
+</svg>


### PR DESCRIPTION
Adds a marketplace entry for **Ayu** (`ayu`).

## What the plugin does

Ships the three [ayu](https://github.com/ayu-theme/ayu-colors) themes — Light, Dark and Mirage — as BB themes, plus a Settings → Ayu panel that switches between them and lets you copy any colour the palette publishes, and a `bb ayu` CLI for agents and scripts.

Each variant is a whole theme rather than a light/dark pair: one stylesheet paints both of BB's modes, so selecting Ayu Dark gives Ayu Dark whichever way the light/dark switch is set. Colours are generated from the upstream `ayu` npm package (9.1.0-beta.0) by `scripts/generate-themes.mjs`; nothing is blended or contrast-corrected. The README documents the full ayu → BB token mapping, including the `--sh-*` sugar-high bridge for chat code blocks.

## Source release

- Repository: https://github.com/vburojevic/bb-plugin-ayu (public)
- Source: git, `range: "^0.2.0"`
- Tag `v0.2.0` → commit `7eaf280ee6088784fdf64f34f66373d6ae896044`
- Plugin at the repository root, so no `subdir` and no `tagPrefix`.

The plugin id `ayu` is derived from the package name `bb-plugin-ayu` and matches both the entry filename and the built manifest (`dist/app.meta.json` → `"pluginId": "ayu"`).

## Plugin checks

- `npm run typecheck` (`tsc --noEmit`) — clean.
- `bb plugin build` — clean, and byte-identical across two consecutive runs, so the committed `dist/` matches the source at the tagged commit.
- Working tree clean at the release commit; the tag was created after that commit and has not been moved.

## Marketplace checks

- `npm ci --ignore-scripts`
- `npm run build` — composes `dist/marketplace.json` with 4 entries.
- `npm run check` — passes; the liveness check resolves `^0.2.0` against the published `v0.2.0` tag.

## Icon

`icons/ayu-9660fa88.svg` is the plugin's own three-dot mark, rescaled from its 16 to a 24 viewBox to sit with BB's icon set. Following the note in `icons/` that BB renders plugin icons as CSS masks keyed off alpha coverage, it has no background plate and uses an opaque literal fill rather than `currentColor`. Verified through a real CSS mask at 48/32/24/16 px on light, dark and ayu backgrounds. 735 bytes, no scripts, no remote references, no embedded data.

## Permissions, services and security

- No network access, no external services, no telemetry, no credentials.
- The backend exposes two rpc methods (read the active theme, set the theme via `bb.sdk.theme.set()`) and publishes a `theme-changed` realtime signal so open panels stay in sync. Palette data never crosses rpc — `generated/palettes.ts` is a plain module the frontend bundles directly.
- The `bb ayu` CLI reads generated colour data and prints it.
- Theme CSS declares custom properties only.

Colours are MIT-licensed by the ayu project (Ike Ku / Konstantin Pschera).
