### PR TITLE
Add plugin entry: dispatch

### DIFF
--- a/entries/dispatch.json
+++ b/entries/dispatch.json
@@ -2,7 +2,9 @@
   "id": "dispatch",
   "displayName": "Dispatch",
   "description": "Turns a one-liner into a scoped thread in the right project: classifies which bb project it belongs to, expands it into a full prompt, and spawns the thread.",
-  "icon": "Send",
+  "icon": {
+    "url": "./icons/dispatch-8bca247f.svg"
+  },
   "tags": [
     "threads",
     "prompts",

--- a/entries/dispatch.json
+++ b/entries/dispatch.json
@@ -1,0 +1,24 @@
+{
+  "id": "dispatch",
+  "displayName": "Dispatch",
+  "description": "Turns a one-liner into a scoped thread in the right project: classifies which bb project it belongs to, expands it into a full prompt, and spawns the thread.",
+  "icon": "Send",
+  "tags": [
+    "threads",
+    "prompts",
+    "agent-interaction",
+    "task-routing",
+    "prompt-expansion"
+  ],
+  "author": {
+    "name": "Shane Logsdon",
+    "github": "slogsdon",
+    "url": "https://github.com/slogsdon"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/slogsdon/bb-plugin-dispatch.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/entries/dispatch.json
+++ b/entries/dispatch.json
@@ -16,8 +16,8 @@
     "url": "https://github.com/slogsdon"
   },
   "source": {
-    "git": {
-      "url": "https://github.com/slogsdon/bb-plugin-dispatch.git",
+    "npm": {
+      "package": "bb-plugin-dispatch",
       "range": "^0.1.0"
     }
   }

--- a/icons/dispatch-8bca247f.svg
+++ b/icons/dispatch-8bca247f.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Hugeicons SentIcon (free set, MIT), vendored for the BB marketplace listing. -->
+  <path d="M21.0477 3.05293C18.8697 0.707363 2.48648 6.4532 2.50001 8.551C2.51535 10.9299 8.89809 11.6617 10.6672 12.1581C11.7311 12.4565 12.016 12.7625 12.2613 13.8781C13.3723 18.9305 13.9301 21.4435 15.2014 21.4996C17.2278 21.5892 23.1733 5.342 21.0477 3.05293Z" stroke="currentColor" stroke-width="1.5"/>
+  <path d="M11.4999 12.5L14.9999 9" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+</svg>


### PR DESCRIPTION
## What the plugin does

Dispatch turns a one-liner into a scoped thread in the right project. It classifies which of your registered bb projects the request belongs to, expands it into a full prompt, and spawns the thread. `bb dispatch "fix the flaky auth test"` previews; `--go` spawns. A Dispatch nav panel does the same and drops you into the new thread.

Project, provider, model, reasoning level, permission mode, and environment come from a saved "lane" picked with `experimental_NewThreadComposer` in a settings section, so the plugin declares no settings of its own.

## Source release

- Repository: https://github.com/slogsdon/bb-plugin-dispatch
- Release tag: `v0.1.0`
- Marketplace range: `^0.1.0`
- Plugin SDK: `^0.4.1` (published; current npm is 0.4.4)

## Checks

- Marketplace `npm ci --ignore-scripts`
- Marketplace `npm run build`
- Marketplace `npm run check` (liveness passes; `v0.1.0` resolves)

The plugin loads TypeScript sources directly and has no build step.

## Permissions and external services

Runs on the machine hosting the bb server. Classification and prompt expansion go through the provider/model selected in the saved lane — no separate credentials, no third-party services beyond the agent provider bb is already configured with. The saved lane and enhancer config are the only state, kept in `bb.storage.kv`.

## Note

Originally submitted as get-bb/bb#1636 and redirected here.
