### PR TITLE
Add plugin entry: lanes

### DIFF
--- a/entries/lanes.json
+++ b/entries/lanes.json
@@ -1,0 +1,25 @@
+{
+  "id": "lanes",
+  "displayName": "Lanes",
+  "description": "Shows every model lane's headroom in one place, adding OpenCode Zen Go and OpenRouter gauges alongside bb's native Claude Code and Codex tracking.",
+  "icon": "Gauge",
+  "tags": [
+    "usage",
+    "rate-limits",
+    "claude-code",
+    "codex",
+    "openrouter",
+    "opencode"
+  ],
+  "author": {
+    "name": "Shane Logsdon",
+    "github": "slogsdon",
+    "url": "https://github.com/slogsdon"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/slogsdon/bb-plugin-lanes.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/entries/lanes.json
+++ b/entries/lanes.json
@@ -2,7 +2,9 @@
   "id": "lanes",
   "displayName": "Lanes",
   "description": "Shows every model lane's headroom in one place, adding OpenCode Zen Go and OpenRouter gauges alongside bb's native Claude Code and Codex tracking.",
-  "icon": "Gauge",
+  "icon": {
+    "url": "./icons/lanes-d0a16007.svg"
+  },
   "tags": [
     "usage",
     "rate-limits",

--- a/entries/lanes.json
+++ b/entries/lanes.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/slogsdon"
   },
   "source": {
-    "git": {
-      "url": "https://github.com/slogsdon/bb-plugin-lanes.git",
+    "npm": {
+      "package": "bb-plugin-lanes",
       "range": "^0.1.0"
     }
   }

--- a/icons/lanes-d0a16007.svg
+++ b/icons/lanes-d0a16007.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Hugeicons DashboardSpeed01Icon (free set, MIT), vendored for the BB marketplace listing. -->
+  <path d="M13.5 13L17 9M14 15C14 16.1046 13.1046 17 12 17C10.8954 17 10 16.1046 10 15C10 13.8954 10.8954 13 12 13C13.1046 13 14 13.8954 14 15Z" stroke="currentColor" stroke-linecap="round" stroke-width="1.5"/>
+  <path d="M6 12C6 8.68629 8.68629 6 12 6C13.0929 6 14.1175 6.29218 15 6.80269" stroke="currentColor" stroke-linecap="round" stroke-width="1.5"/>
+  <path d="M2.50006 12.0001C2.50006 7.52172 2.50006 5.28255 3.8913 3.8913C5.28255 2.50006 7.52172 2.50006 12.0001 2.50006C16.4784 2.50006 18.7176 2.50006 20.1088 3.8913C21.5001 5.28255 21.5001 7.52172 21.5001 12.0001C21.5001 16.4784 21.5001 18.7176 20.1088 20.1088C18.7176 21.5001 16.4784 21.5001 12.0001 21.5001C7.52172 21.5001 5.28255 21.5001 3.8913 20.1088C2.50006 18.7176 2.50006 16.4784 2.50006 12.0001Z" stroke="currentColor" stroke-width="1.5"/>
+</svg>


### PR DESCRIPTION
## What the plugin does

Lanes shows every model lane's headroom in one place. bb tracks Claude Code and Codex subscription windows natively; Lanes adds OpenCode Zen Go and OpenRouter, normalised into the same `{label, usedPercent, resetsAt}` shape. A settings section shows all four, and `bb lanes` / `bb lanes --json` expose the same data for agents deciding where to route work.

Subscriptions and balances render differently on purpose: quota windows show a countdown to `resetsAt`, while OpenRouter shows remaining dollars and no countdown, because it depletes rather than throttles.

## Source release

- Repository: https://github.com/slogsdon/bb-plugin-lanes
- Release tag: `v0.1.0`
- Marketplace range: `^0.1.0`
- Plugin SDK: `^0.4.1` (published; current npm is 0.4.4)

## Checks

- Marketplace `npm ci --ignore-scripts`
- Marketplace `npm run build`
- Marketplace `npm run check` (liveness passes; `v0.1.0` resolves)

The plugin loads TypeScript sources directly and has no build step.

## Permissions and external services

Reads OpenCode Zen Go and OpenRouter API keys from `~/.bb/env.json` (falling back to `process.env`) on the machine hosting the bb server, and calls `https://opencode.ai/zen/go/v1/usage` and `https://openrouter.ai/api/v1/credits` to read quota and balance. No credentials are sent anywhere else and nothing is written back.

## Note

Originally submitted as get-bb/bb#1637 and redirected here. Related to get-bb/bb#1620: the natural home is Settings → Usage limits, but that page is host-owned and `PluginSettingsSectionRegistration` has no page selector, so it lists under Extensions → Plugins for now.
