### PR TITLE
Add plugin entry: wterm-terminal-preview

### DIFF
--- a/entries/wterm-terminal-preview.json
+++ b/entries/wterm-terminal-preview.json
@@ -1,0 +1,24 @@
+{
+  "id": "wterm-terminal-preview",
+  "displayName": "Wterm Terminal Preview",
+  "description": "Adds a Ghostty-backed terminal with independent tabs, TUI mouse input, secure file transfer, and font controls.",
+  "icon": "Terminal",
+  "tags": [
+    "terminal",
+    "developer-tools",
+    "ssh",
+    "file-transfer",
+    "ghostty"
+  ],
+  "author": {
+    "name": "Andrew Kiryushkin",
+    "github": "Diffuzmetall",
+    "url": "https://github.com/Diffuzmetall"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/Diffuzmetall/bb-wterm-terminal-plugin.git",
+      "range": "^0.3.14"
+    }
+  }
+}


### PR DESCRIPTION
## What the plugin does

Wterm adds a Ghostty-backed terminal panel to BB. Each Wterm tab owns an independent thread-scoped terminal and supports keyboard, resize, wheel, TUI mouse input, browser-native selection, font sizing, and authenticated file or image transfer to the terminal host.

## Source release

- Repository: https://github.com/Diffuzmetall/bb-wterm-terminal-plugin
- Release tag: `v0.3.14`
- Marketplace range: `^0.3.14`
- Derived plugin id: `wterm-terminal-preview`
- BB: `>=0.35.1`; Plugin SDK: `^0.4.1`

## Plugin checks

- Node.js 22.19: 15 tests passed
- Clean production-only install: passed, 0 vulnerabilities
- `bb plugin build .` against public `bb-app@0.38.0`: passed
- Release CI: https://github.com/Diffuzmetall/bb-wterm-terminal-plugin/actions/runs/31903723809

## Marketplace checks

- `npm ci --ignore-scripts`
- `npm run build`
- `npm run check`

## Permissions and external services

The plugin attaches only to terminal sessions owned by the current BB thread. File and image uploads use authenticated plugin routes and `bb.sdk.files.write` on that terminal's host, with randomized paths, 0600 mode, size limits, and returned size/SHA-256 verification. It makes no external network requests, has no telemetry, and stores no credentials. The bundled Ghostty WASM and Nerd Font are documented in the repository.

This is an early public preview and intentionally uses the distinct `wterm-terminal-preview` id so it can coexist with BB's bundled terminal while the integration is evaluated.
