### PR TITLE
Add plugin entry: files

### DIFF
--- a/entries/files.json
+++ b/entries/files.json
@@ -1,0 +1,18 @@
+{
+  "id": "files",
+  "displayName": "Files",
+  "description": "Browse and safely edit files in the current BB thread environment.",
+  "icon": "FolderOpen",
+  "tags": ["developer-tools", "files", "editor"],
+  "author": {
+    "name": "Andrew Kiryushkin",
+    "github": "Diffuzmetall",
+    "url": "https://github.com/Diffuzmetall"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/Diffuzmetall/bb-plugin-files.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/entries/files.json
+++ b/entries/files.json
@@ -3,7 +3,11 @@
   "displayName": "Files",
   "description": "Browse and safely edit files in the current BB thread environment.",
   "icon": "FolderOpen",
-  "tags": ["developer-tools", "files", "editor"],
+  "tags": [
+    "developer-tools",
+    "files",
+    "editor"
+  ],
   "author": {
     "name": "Andrew Kiryushkin",
     "github": "Diffuzmetall",
@@ -14,5 +18,6 @@
       "url": "https://github.com/Diffuzmetall/bb-plugin-files.git",
       "range": "^0.1.0"
     }
-  }
+  },
+  "category": "file-viewers-and-editors"
 }


### PR DESCRIPTION
## What the plugin does

Files adds a thread-scoped file manager and CodeMirror editor to BB. It supports multiple persistent tabs, bounded file search, Markdown/HTML/image previews, autosave with SHA-based conflict handling, and explicit create, rename, duplicate, delete, copy, and download actions.

## Source release

- Repository: https://github.com/Diffuzmetall/bb-plugin-files
- Release tag: `v0.1.0`
- Marketplace range: `^0.1.0`
- Derived plugin id: `files`
- BB: `>=0.35.1`; Plugin SDK: `^0.4.1`

## Plugin checks

- Typecheck: passed
- Tests: 39 passed
- Clean production-only install: passed, 0 vulnerabilities
- `bb plugin build .` against official `bb-app@0.38.0`: passed
- Release CI: https://github.com/Diffuzmetall/bb-plugin-files/actions/runs/31903884964

## Marketplace checks

- `npm ci --ignore-scripts`
- `npm run build`
- `npm run check`

## Permissions and external services

Files can read, create, edit, rename, duplicate, download, and recursively delete workspace files. Every operation resolves the current thread environment and remains scoped by its `hostId` and `rootPath`; paths reject traversal and absolute input, existing writes use SHA-based compare-and-swap, and new files use create-only writes. The plugin intentionally discovers common dotfiles, including `.env` and `.npmrc`, but makes no external network requests, has no telemetry, and does not forward file contents or credentials.
