### PR TITLE
Add plugin entry: excalidraw

### DIFF
--- a/entries/excalidraw.json
+++ b/entries/excalidraw.json
@@ -1,0 +1,20 @@
+{
+  "id": "excalidraw",
+  "displayName": "Excalidraw",
+  "description": "Adds native Excalidraw canvases, revision-safe agent tools, and matching CLI commands for workspace drawings.",
+  "icon": {
+    "url": "./icons/excalidraw-d59c6100.svg"
+  },
+  "tags": ["diagrams", "drawing", "files", "agents"],
+  "author": {
+    "name": "Andrew Kiryushkin",
+    "github": "Diffuzmetall",
+    "url": "https://github.com/Diffuzmetall"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/Diffuzmetall/bb-plugin-excalidraw.git",
+      "range": "^0.1.1"
+    }
+  }
+}

--- a/icons/excalidraw-d59c6100.svg
+++ b/icons/excalidraw-d59c6100.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m14.5 4.5 5 5"/><path d="M5 19l1.5-5.5L16.5 3.5a2.12 2.12 0 0 1 3 3L9.5 16.5z"/><path d="M5 19h4"/></svg>


### PR DESCRIPTION
## What the plugin does

Excalidraw adds native workspace-backed canvases to BB, plus bounded semantic read/create/apply tools, matching `bb excalidraw` CLI commands, and an agent skill for diagram design. Human and agent writes share SHA-256 compare-and-swap, conflict handling, and realtime invalidation instead of silent last-writer-wins behavior.

## Source release

- Repository: https://github.com/Diffuzmetall/bb-plugin-excalidraw
- Release tag: `v0.1.1`
- Marketplace range: `^0.1.1`
- Derived plugin id: `excalidraw`
- BB: `>=0.35.1`; Plugin SDK: `^0.4.1`

## Plugin checks

- Typecheck: passed
- Unit/integration tests: 111 passed
- Chromium browser tests: 8 passed
- Clean production-only install and real `bb plugin build .`: passed
- Release CI: https://github.com/Diffuzmetall/bb-plugin-excalidraw/actions/runs/31903939296

## Marketplace checks

- `npm ci --ignore-scripts`
- `npm run build`
- `npm run check`

## Permissions, external services, and dependency disclosure

The plugin reads and writes `.excalidraw` files only inside the current thread workspace. Agent operations use bounded semantic schemas, reject absolute/traversal paths, require the expected SHA-256 for updates, and never expose raw scene JSON or embedded image bodies. It has no telemetry, credentials, or external runtime service.

The production dependency audit currently reports 2 high and 7 moderate transitive advisories through `@excalidraw/excalidraw` and its Mermaid parser dependencies, with 0 critical findings. There is no compatible fixed Excalidraw release at submission time. The plugin does not expose Mermaid parsing, and the current status and upgrade policy are documented in SECURITY.md.

The submitted icon is the plugin's own MIT-licensed mark converted to an opaque mask-safe stroke, with a content-addressed filename and no scripts, remote resources, or embedded data.
