### PR TITLE
Add Arc Switcher plugin

### DIFF
--- a/entries/arc-switcher.json
+++ b/entries/arc-switcher.json
@@ -1,0 +1,17 @@
+{
+  "id": "arc-switcher",
+  "displayName": "Arc Switcher",
+  "description": "Cycles through your seven most recently opened BB chats with an Arc-style Command-D switcher.",
+  "icon": "Layers",
+  "tags": ["interface", "keyboard-shortcuts", "navigation", "threads"],
+  "author": {
+    "name": "Elliott McNary",
+    "github": "bighitbiker3"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/bighitbiker3/bb-plugin-arc-switcher.git",
+      "range": "^0.1.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- list Arc Switcher in the BB Community marketplace
- install from the public `bighitbiker3/bb-plugin-arc-switcher` repository using the `^0.1.0` release range
- surface the plugin with its manifest-aligned Layers icon and navigation/thread tags

Arc Switcher intercepts Command-D while BB is focused and shows an Arc-style switcher for the seven most recently opened chats. It also gives chats stable emoji markers in the switcher, sidebar, and thread header, with an optional integration for project emojis.

<img width="1638" height="1048" alt="Screenshot 2026-08-15 at 4 57 18 PM" src="https://github.com/user-attachments/assets/542aa931-7f9d-47f9-926d-f3a2a60038ef" />

## Validation

- `npm run build`
- `npm run check`
- clean clone of the public `v0.1.0` tag followed by `npm ci`, `npm run typecheck`, and `npm run build`
- plugin is loaded locally with running status and no handler errors
