### PR TITLE
Add plugin entry: attention

### DIFF
--- a/entries/attention.json
+++ b/entries/attention.json
@@ -1,0 +1,23 @@
+{
+  "id": "attention",
+  "displayName": "Needs Attention",
+  "description": "Ranks the top threads that need you on the bb homepage: errors, pending input, and unread finished turns, most urgent first.",
+  "icon": "AlertCircle",
+  "tags": [
+    "threads",
+    "homepage",
+    "attention",
+    "notifications"
+  ],
+  "author": {
+    "name": "Shane Logsdon",
+    "github": "slogsdon",
+    "url": "https://github.com/slogsdon"
+  },
+  "source": {
+    "npm": {
+      "package": "bb-plugin-attention",
+      "range": "^0.1.0"
+    }
+  }
+}


### PR DESCRIPTION
## What it does

Adds a "Needs attention" section to the bb homepage / new-thread screen: the top 10 threads ranked by urgency (`error` → `interaction` → `unread`), with hidden/archived/still-running threads excluded. Also exposes `bb attention list [--project <id>]`.

## Source

- npm package: `bb-plugin-attention` at `^0.1.0` (freshly published, `v0.1.0` tag on the repo)
- Repo: https://github.com/slogsdon/bb-plugin-attention

## Checks

- Plugin: `vitest run` (rank/filter/cap/CLI tests), `tsc --noEmit`, `bb plugin build`; tarball verified to include `dist/`
- Marketplace: `npm run build` + `npm run check` pass on this branch

## Notes

No external services or special permissions. Plugin id `attention` matches the manifest.
