### PR TITLE
Add plugin entry: auto-archive

### DIFF
--- a/entries/auto-archive.json
+++ b/entries/auto-archive.json
@@ -1,0 +1,23 @@
+{
+  "id": "auto-archive",
+  "displayName": "Auto Archive",
+  "description": "Automatically archives bb threads that have seen no activity for a configurable number of days.",
+  "icon": "Archive",
+  "tags": [
+    "threads",
+    "archive",
+    "automation",
+    "cleanup"
+  ],
+  "author": {
+    "name": "Shane Logsdon",
+    "github": "slogsdon",
+    "url": "https://github.com/slogsdon"
+  },
+  "source": {
+    "npm": {
+      "package": "bb-plugin-auto-archive",
+      "range": "^0.1.0"
+    }
+  }
+}


### PR DESCRIPTION
## What it does

Runs a scheduled sweep that auto-archives bb threads with no recent activity. The inactivity threshold (in days) is configurable per bb installation.

## Source

- npm package: `bb-plugin-auto-archive` at `^0.1.0` (freshly published, `v0.1.0` tag on the repo)
- Repo: https://github.com/slogsdon/bb-plugin-auto-archive

## Checks

- Plugin: `vitest run`, `bb plugin build`; tarball verified to include `dist/`
- Marketplace: `npm run build` + `npm run check` pass on this branch

## Notes

Runs a local background service inside bb (archive sweep). No external services. Plugin id `auto-archive` matches the manifest.
