### PR TITLE
Add plugin entry: global-workflows

### DIFF
--- a/entries/global-workflows.json
+++ b/entries/global-workflows.json
@@ -1,0 +1,22 @@
+{
+  "id": "global-workflows",
+  "displayName": "Global Workflows",
+  "description": "Runs bb workflows from any project, from a catalog that lives outside every repository.",
+  "icon": "Workflow",
+  "tags": [
+    "workflows",
+    "automation",
+    "orchestration"
+  ],
+  "author": {
+    "name": "Shane Logsdon",
+    "github": "slogsdon",
+    "url": "https://github.com/slogsdon"
+  },
+  "source": {
+    "npm": {
+      "package": "bb-plugin-global-workflows",
+      "range": "^0.1.0"
+    }
+  }
+}


### PR DESCRIPTION
## What it does

Runs bb workflows from any project, from a catalog that lives outside every repo. Adds a `bb global-workflows list|run` CLI and a thread-header panel. Catalog location defaults to `<dataDir>/plugins/global-workflows/workflows/`, override with the `catalogDir` setting.

## Source

- npm package: `bb-plugin-global-workflows` at `^0.1.0` (freshly published, `v0.1.0` tag on the repo)
- Repo: https://github.com/slogsdon/bb-plugin-global-workflows

## Checks

- Plugin: `tsc --noEmit`, `bb plugin build`; tarball verified to include `dist/`
- Marketplace: `npm run build` + `npm run check` pass on this branch

## Notes

No external services. Plugin id `global-workflows` matches the manifest.
