### PR TITLE
Add plugin entry: ntfy

### DIFF
--- a/entries/ntfy.json
+++ b/entries/ntfy.json
@@ -1,0 +1,23 @@
+{
+  "id": "ntfy",
+  "displayName": "ntfy notifications",
+  "description": "Pushes a notification to your phone via ntfy.sh when a bb thread needs your attention: finished unread turns, failures, and pending approvals.",
+  "icon": "Bell",
+  "tags": [
+    "notifications",
+    "ntfy",
+    "push",
+    "mobile"
+  ],
+  "author": {
+    "name": "Shane Logsdon",
+    "github": "slogsdon",
+    "url": "https://github.com/slogsdon"
+  },
+  "source": {
+    "npm": {
+      "package": "bb-plugin-ntfy",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/entries/ntfy.json
+++ b/entries/ntfy.json
@@ -2,7 +2,9 @@
   "id": "ntfy",
   "displayName": "ntfy notifications",
   "description": "Pushes a notification to your phone via ntfy.sh when a bb thread needs your attention: finished unread turns, failures, and pending approvals.",
-  "icon": "Bell",
+  "icon": {
+    "url": "./icons/ntfy-2ef77317.svg"
+  },
   "tags": [
     "notifications",
     "ntfy",

--- a/icons/ntfy-2ef77317.svg
+++ b/icons/ntfy-2ef77317.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Hugeicons Notification02Icon (free set, MIT), vendored for the BB marketplace listing. -->
+  <path d="M19 18V9.5C19 5.63401 15.866 2.5 12 2.5C8.13401 2.5 5 5.63401 5 9.5V18" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+  <path d="M20.5 18H3.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+  <path d="M13.5 20C13.5 20.8284 12.8284 21.5 12 21.5M10.5 20C10.5 20.8284 11.1716 21.5 12 21.5M12 21.5V20" stroke="currentColor" stroke-linejoin="round" stroke-width="1.5"/>
+</svg>


### PR DESCRIPTION
## What it does

Pushes notifications to your phone via ntfy.sh when a bb thread needs your attention: finished unread turns, failures, and pending approvals. Configurable ntfy topic and server.

## Source

- npm package: `bb-plugin-ntfy` at `^0.1.0` (freshly published, `v0.1.0` tag on the repo)
- Repo: https://github.com/slogsdon/bb-plugin-ntfy

## Checks

- Plugin: `vitest run`, `tsc --noEmit`, `bb plugin build`; tarball verified to include `dist/`
- Marketplace: `npm run build` + `npm run check` pass on this branch

## Notes

Outbound HTTP calls to the configured ntfy server only (default `ntfy.sh`); the topic is user-configured. Plugin id `ntfy` matches the manifest.
