### PR TITLE
Add Context Meter: keep threads in the smart zone

### DIFF
--- a/entries/context-meter.json
+++ b/entries/context-meter.json
@@ -1,0 +1,25 @@
+{
+  "id": "context-meter",
+  "displayName": "Context Meter",
+  "description": "Keeps threads in the smart zone, by tracking context against a limit you set rather than the provider's full window.",
+  "icon": {
+    "url": "./icons/context-meter-929a505a.svg"
+  },
+  "tags": [
+    "interface",
+    "composer",
+    "context",
+    "tokens",
+    "smart-zone"
+  ],
+  "author": {
+    "name": "Roger Serra",
+    "github": "Hazihell"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/Hazihell/bb-plugin-context-meter.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/icons/context-meter-929a505a.svg
+++ b/icons/context-meter-929a505a.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+     stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- A meter track, a part-filled bar, and a tick marking the user's soft
+       limit: the one thing this plugin adds over BB's own context ring.
+       Outline style to match BB's stroked icon set (1.5 at a 24 viewBox).
+       BB renders plugin icons as CSS masks, which key off alpha coverage, so
+       the stroke is an opaque literal rather than currentColor, which has no
+       inherited context inside a mask source. -->
+  <rect x="2.75" y="8.75" width="18.5" height="6.5" rx="3.25"/>
+  <path d="M6.25 12h5" stroke-width="3"/>
+  <path d="M16.25 5.75v12.5"/>
+</svg>


### PR DESCRIPTION
## What the plugin does

Context Meter shows how close a thread is to leaving the smart zone, as a slim
line above the composer: a bar, then `170k / 150k`.

The premise is that a model's advertised window is not its usable range. This is
the smart zone and dumb zone distinction: quality degrades well before the
window fills, so a thread can be deep in the dumb zone while the provider's
gauge still reads nearly empty.

The evidence, for anyone who wants to check the framing:

| Source | Finding |
| --- | --- |
| [Chroma, *Context Rot*](https://www.trychroma.com/research/context-rot) (2025) | All 18 frontier models tested degrade as input grows, "often in surprising and non-uniform ways". |
| [Liu et al., *Lost in the Middle*](https://arxiv.org/abs/2307.03172) (2023) | Attention follows a U curve; facts in the middle of a long context get missed. |
| [Matt Pocock](https://finance.biggo.com/news/e7209c094224b09c) | Smart zone at roughly 100k tokens; calls a 1M window "effectively shipping more dumb zone" for reasoning work. |
| [Duncan Leung](https://duncanleung.com/blog/llm-smart-zone-dumb-zone-context-window-degradation/) | Smart below 100k, warn 100k to 200k, dumb above 200k. |

The important structural point is that these thresholds are **absolute, not a
percentage of the window**. A 1M model at 40% full is 400k tokens deep and badly
degraded; a 200k model at 40% is at 80k and fine. That is exactly why a bar
filling against the provider's number cannot do this job.

So the plugin fills against a limit the user sets (`softLimit`, default 150000,
accepts `150k` or `1.5m`). 150000 puts the amber warning at 112k, just past the
100k figure the sources converge on, and red mid warning band. The README
documents this and tells users to set 100k if they want the colours to map to
the published bands exactly.

BB's built-in ring cannot serve that purpose, for two separate reasons:

1. It fills against the provider's window. On a 1M model, 170k tokens reads as
   17% full, a bar that looks nearly empty at the exact moment the thread is
   deep in the dumb zone. This applies on desktop as much as on mobile.
2. The compact composer layout collapses the footer row that holds the ring, so
   on a phone there is no number at all. Composer banners have no compact gate,
   so this line survives there.

The second point is why the plugin renders where it does. The first is why it
exists.

## What it looks like

The same thread at three points, all against a 150k limit:

- `125k / 150k`, amber, bar at 83%.
- `170k / 150k`, red, bar clamped at full while the count keeps climbing past
  the limit, because the limit is a target and not a wall.
- `43k / 150k`, muted, bar at 29%, after a compaction.

That last one is the recovery case, and it is the one worth knowing about. A
compaction clears `contextWindowUsage`, so the line hides rather than showing a
misleading `0k`, then comes back with the new number as soon as the next turn
ends.

Values BB marks as estimated get a leading `~`, since that error matters more
against a 150k target than against 1M.

Hovering gives exact tokens, the limit, the model's real window, and whether the
value was estimated.

## Source

- Repository: https://github.com/Hazihell/bb-plugin-context-meter
- Release tag: `v0.1.6`
- Entry range: `^0.1.0`
- Licence: MIT

## What reviewers should look at

The backend does two things that touch host data, both listed here so they are
not a surprise:

- `bb.sdk.threads.timeline({ summaryOnly: "true", segmentLimit: "1" })` to read
  `contextWindowUsage` for one thread. It requests no rows.
- `bb.sdk.subscribe({ event: "thread:changed" })` without a thread filter, so it
  can push updates for whichever thread the user is looking at. It ignores every
  event whose `metadata.eventTypes` does not include
  `thread/contextWindowUsage/updated` or `thread/tokenUsage/updated`.

Numbers are republished with `bb.realtime.publish` on channel `usage`. The
payload is the token count, the model window, the estimated flag, and the
resolved limit. No thread content is read or transmitted. There are no network
calls, no external services, no credentials, and no filesystem access. One
runtime dependency, `zod`.

## Plugin checks

- `tsc --noEmit` clean, with `skipLibCheck: false`.
- `bb plugin build` produces `dist/server.js`, `dist/app.js`, `dist/app.css`,
  and both `*.meta.json` files. They are committed at the tag, so a git install
  needs no build step. Source maps are gitignored.
- Installed locally and exercised against three live threads on BB 0.38.0.
  Verified the realtime path end to end: BB emitted
  `thread/contextWindowUsage/updated`, the plugin republished, and a subscribed
  client received the numbers.
- The tagged tree was re-cloned to confirm the manifest, icon, and all five
  build artifacts are present.
- Clone is 828K shallow, 840K full, no images and no source maps, in line with
  the other listed plugins.

## Marketplace checks

- `npm ci --ignore-scripts`
- `npm run build` passes: `built dist/marketplace.json with 5 entries`
- `npm run check` passes, including the liveness check against the git tag
- Entry id, filename, and the id derived from the package manifest all agree on
  `context-meter`
- Icon is a 24px stroked SVG matching the existing icon style, 733 bytes, no
  scripts and no remote references
