### PR TITLE
Add plugin entry: taskboard

### DIFF
--- a/entries/taskboard.json
+++ b/entries/taskboard.json
@@ -1,0 +1,27 @@
+{
+  "id": "taskboard",
+  "displayName": "Taskboard",
+  "description": "Brings each BB project's GitHub, Linear, or Jira tasks into one focused List or Kanban board.",
+  "icon": {
+    "url": "./icons/taskboard-0b77950c.svg"
+  },
+  "tags": [
+    "tasks",
+    "project-management",
+    "kanban",
+    "github",
+    "linear",
+    "jira"
+  ],
+  "author": {
+    "name": "Mateo Cerquetella",
+    "github": "MateoCerquetella",
+    "url": "https://github.com/MateoCerquetella"
+  },
+  "source": {
+    "npm": {
+      "package": "bb-plugin-taskboard",
+      "range": "^0.1.2"
+    }
+  }
+}

--- a/icons/taskboard-0b77950c.svg
+++ b/icons/taskboard-0b77950c.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+     stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- A single Taskboard ticket. The opaque stroke is intentional: BB
+       renders compact plugin artwork as a CSS mask. -->
+  <path d="M5 4h14a2 2 0 0 1 2 2v3a3 3 0 0 0 0 6v3a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-3a3 3 0 0 0 0-6V6a2 2 0 0 1 2-2Z"/>
+</svg>


### PR DESCRIPTION
## What the plugin does

Taskboard brings each BB project's GitHub, Linear, or Jira tasks into a focused List or Kanban board. It supports provider-native workflows and filters, live task details, project-specific tracker configuration, and agent handoff from a task.

## Source release

- npm package: https://www.npmjs.com/package/bb-plugin-taskboard
- Marketplace range: `^0.1.2`
- Derived plugin id: `taskboard`
- Source: https://github.com/MateoCerquetella/bb-plugins/tree/main/plugins/taskboard
- Current release compatibility: BB `>=0.36`; plugin SDK `^0.4.1`
- BB 0.38 SDK migration: https://github.com/MateoCerquetella/bb-plugins/pull/6

## Plugin checks

The BB 0.38 migration branch passes:

- SDK sync check against `@get-bb/plugin-sdk@0.4.6`
- TypeScript typecheck
- 10 tests
- `bb plugin build .` against `bb-app@0.38.0`
- server/app artifact metadata verification
- npm package dry-run with built artifacts and source fallback entries

## Marketplace checks

- `npm ci`
- `npm run build`
- `npm run check`

## Permissions and external services

Taskboard is a full-trust BB plugin. It reads BB project metadata and reuses BB's official GitHub plugin for mapped repositories. For Linear or Jira, users explicitly configure project-scoped credentials; secret values are stored in owner-only files and are never returned to the frontend or CLI. The plugin contacts only the selected tracker, caches task summaries in its plugin database, and fetches descriptions and comments live. It has no telemetry.

The submitted SVG is the plugin's own compact icon from its MIT-licensed source package.