### PR TITLE
Add plugin entry: usage-tracker

### DIFF
--- a/entries/usage-tracker.json
+++ b/entries/usage-tracker.json
@@ -1,0 +1,24 @@
+{
+  "id": "usage-tracker",
+  "displayName": "Usage Tracker",
+  "description": "Shows compact Codex and Claude Code five-hour and weekly usage limits in the BB sidebar footer.",
+  "icon": "ChartColumn",
+  "tags": [
+    "usage",
+    "rate-limits",
+    "codex",
+    "claude-code",
+    "sidebar"
+  ],
+  "author": {
+    "name": "Mateo Cerquetella",
+    "github": "MateoCerquetella",
+    "url": "https://github.com/MateoCerquetella"
+  },
+  "source": {
+    "npm": {
+      "package": "bb-plugin-usage-tracker",
+      "range": "^0.1.1"
+    }
+  }
+}


### PR DESCRIPTION
## What the plugin does

Usage Tracker adds compact Codex and Claude Code five-hour and weekly limit readings to BB's sidebar footer. Either provider can be shown independently, expanded for reset details, and refreshed without leaving the current thread.

## Source release

- npm package: https://www.npmjs.com/package/bb-plugin-usage-tracker
- Marketplace range: `^0.1.1`
- Derived plugin id: `usage-tracker`
- Source: https://github.com/MateoCerquetella/bb-plugins/tree/main/plugins/usage-tracker
- Current release compatibility: BB `>=0.36`; plugin SDK `^0.4.1`
- BB 0.38 SDK migration: https://github.com/MateoCerquetella/bb-plugins/pull/6

## Plugin checks

The BB 0.38 migration branch passes:

- SDK sync check against `@get-bb/plugin-sdk@0.4.6`
- TypeScript typecheck
- 13 tests
- `bb plugin build .` against `bb-app@0.38.0`
- npm package dry-run with built artifacts, source fallback entries, and the 0.1.1 preferences module

## Marketplace checks

- `npm ci`
- `npm run build`
- `npm run check`

## Permissions and external services

Usage Tracker is a trusted BB frontend content script. It reads BB's local `system.usageLimits` data, caches only the last successful usage snapshot and display preferences in browser local storage, and adds a lifecycle-managed row to the sidebar footer. It does not ask for or store provider credentials, make external network requests, or send telemetry.

The entry uses BB's built-in `ChartColumn` icon and adds no third-party artwork to the marketplace repository.