### PR TITLE
Add plugin entry: usage

### DIFF
--- a/entries/usage.json
+++ b/entries/usage.json
@@ -1,0 +1,17 @@
+{
+  "id": "usage",
+  "displayName": "Usage",
+  "description": "Tracks coding-agent token usage and estimated API cost across enrolled machines.",
+  "icon": "ChartColumn",
+  "tags": ["analytics", "costs", "tokens", "usage"],
+  "author": {
+    "name": "Mayank Bansal",
+    "github": "MayankBansal12"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/MayankBansal12/bb-plugin-usage.git",
+      "range": "^0.3.0"
+    }
+  }
+}

--- a/entries/usage.json
+++ b/entries/usage.json
@@ -11,7 +11,7 @@
   "source": {
     "git": {
       "url": "https://github.com/MayankBansal12/bb-plugin-usage.git",
-      "range": "^0.3.0"
+      "range": "^0.3.1"
     }
   }
 }


### PR DESCRIPTION
## What it does

Usage tracks coding-agent token usage and estimated API cost across machines enrolled in BB.

## Source release

- Repository: `MayankBansal12/bb-plugin-usage`
- Release: `v0.3.1` (`99a52a57ff2768a1fe47911ee251978fc6415da5`)
- Marketplace range: `^0.3.1`

## Validation

- TypeScript check passed.
- Plugin tests passed: 54/54.
- `bb plugin build` passed.
- Marketplace `npm run build` and `npm run check` passed.

## Security and external services

The plugin reads local coding-agent usage logs on enrolled machines and stores usage metadata, not prompts or message content. It fetches public model pricing from models.dev with a bundled fallback. OpenCode collection uses a read-only local SQLite query.
