### PR TITLE
Add plugin entry: web-push-notify

### DIFF
--- a/entries/web-push-notify.json
+++ b/entries/web-push-notify.json
@@ -1,0 +1,17 @@
+{
+  "id": "web-push-notify",
+  "displayName": "Web Push Notify",
+  "description": "Sends browser notifications when BB agents finish or fail, even while BB is closed.",
+  "icon": "Mail",
+  "tags": ["agents", "notifications", "web-push"],
+  "author": {
+    "name": "Mayank Bansal",
+    "github": "MayankBansal12"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/MayankBansal12/bb-plugin-web-push-notify.git",
+      "range": "^0.2.0"
+    }
+  }
+}


### PR DESCRIPTION
## What it does

Web Push Notify sends browser notifications when BB agents finish or fail, including while BB is closed.

## Source release

- Repository: `MayankBansal12/bb-plugin-web-push-notify`
- Release: `v0.2.0` (`f10d3d68c852f8ff6031f266f828ac4676d376a8`)
- Marketplace range: `^0.2.0`

## Validation

- TypeScript check passed.
- Plugin tests passed: 20/20.
- `bb plugin build` passed.
- Marketplace `npm run build` and `npm run check` passed.

## Security and external services

The plugin sends notifications directly from the user's BB server through browser Web Push services; it has no hosted backend. Its VAPID private key and push subscriptions are credentials stored in the BB plugin database and should be protected with the database and its backups.
