### PR TITLE
Add plugin entry: image-preview

### DIFF
--- a/entries/image-preview.json
+++ b/entries/image-preview.json
@@ -2,8 +2,15 @@
   "id": "image-preview",
   "displayName": "Image Preview",
   "description": "Adds responsive image grids and a click-to-expand gallery to BB chat messages.",
-  "icon": "Image",
-  "tags": ["chat", "images", "gallery", "interface"],
+  "icon": {
+    "url": "./icons/image-preview-dc6681e8.svg"
+  },
+  "tags": [
+    "chat",
+    "images",
+    "gallery",
+    "interface"
+  ],
   "author": {
     "name": "Dwite",
     "github": "Dwite",

--- a/entries/image-preview.json
+++ b/entries/image-preview.json
@@ -1,0 +1,18 @@
+{
+  "id": "image-preview",
+  "displayName": "Image Preview",
+  "description": "Adds responsive image grids and a click-to-expand gallery to BB chat messages.",
+  "icon": "Image",
+  "tags": ["chat", "images", "gallery", "interface"],
+  "author": {
+    "name": "Dwite",
+    "github": "Dwite",
+    "url": "https://github.com/Dwite"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/Dwite/bb-plugin-image-preview.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/icons/image-preview-dc6681e8.svg
+++ b/icons/image-preview-dc6681e8.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Hugeicons Image01Icon (free set, MIT), vendored for the BB marketplace listing. -->
+  <circle cx="7.5" cy="7.5" r="1.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+  <path d="M2.5 12C2.5 7.52166 2.5 5.28249 3.89124 3.89124C5.28249 2.5 7.52166 2.5 12 2.5C16.4783 2.5 18.7175 2.5 20.1088 3.89124C21.5 5.28249 21.5 7.52166 21.5 12C21.5 16.4783 21.5 18.7175 20.1088 20.1088C18.7175 21.5 16.4783 21.5 12 21.5C7.52166 21.5 5.28249 21.5 3.89124 20.1088C2.5 18.7175 2.5 16.4783 2.5 12Z" stroke="currentColor" stroke-width="1.5"/>
+  <path d="M5 21C9.37246 15.775 14.2741 8.88406 21.4975 13.5424" stroke="currentColor" stroke-width="1.5"/>
+</svg>


### PR DESCRIPTION
## What the plugin does

Image Preview groups multiple images in a BB chat message into a responsive
thumbnail grid, shows a `+X` overflow tile, and opens a themed lightbox with
keyboard and button navigation. Single images remain compact previews.

## Source release

- Repository: `https://github.com/Dwite/bb-plugin-image-preview.git`
- Release tag: `v0.1.0`
- Marketplace range: `^0.1.0`

## Plugin checks

- `npm test` — 7 tests passed
- `npm run typecheck` — passed
- `npm run build` — passed
- `npm pack --dry-run --ignore-scripts` — includes the built `dist/` files

## Marketplace checks

- `npm ci --ignore-scripts` — passed
- `npm run build` — passed
- `npm run check` — passed

## Screenshots

![Gallery grid with overflow tile](https://raw.githubusercontent.com/Dwite/bb-plugin-image-preview/main/docs/screenshots/gallery-grid.png)

![Overflow tile detail](https://raw.githubusercontent.com/Dwite/bb-plugin-image-preview/main/docs/screenshots/gallery-overflow-detail.png)

The plugin uses no external services, secrets, or network APIs. It runs a
frontend content script inside BB and reads only images already rendered in
the current chat surface.
