### PR TITLE
Add Message Timestamps plugin

### DIFF
--- a/entries/message-timestamps.json
+++ b/entries/message-timestamps.json
@@ -1,0 +1,17 @@
+{
+  "id": "message-timestamps",
+  "displayName": "Message Timestamps",
+  "description": "Shows the time you sent each message next to your bubbles in BB chat windows.",
+  "icon": "Clock",
+  "tags": ["interface", "chat", "messages", "threads"],
+  "author": {
+    "name": "Elliott McNary",
+    "github": "bighitbiker3"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/bighitbiker3/bb-plugin-message-timestamps.git",
+      "range": "^0.1.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- list Message Timestamps in the BB Community marketplace
- install from the public `bighitbiker3/bb-plugin-message-timestamps` repository using the `^0.1.0` release range
- surface the plugin with its Clock icon and chat/message tags

Message Timestamps is a custom BB plugin that shows the time you sent each message next to your bubbles in chat windows.

## Test plan
- [x] `npm run build`
- [x] `npm run check`
- [ ] Review listing after merge appears in the BB Community marketplace
- [ ] Install from the catalog and confirm sent-message times render in a chat window


Made with [Cursor](https://cursor.com)