### PR TITLE
Add BB UI Reference plugin

### DIFF
--- a/entries/bb-ui-reference.json
+++ b/entries/bb-ui-reference.json
@@ -1,0 +1,18 @@
+{
+  "id": "bb-ui-reference",
+  "displayName": "BB UI Reference",
+  "description": "Shows BB's plugin surface map alongside live demonstrations of the active semantic theme palette.",
+  "icon": "CircleQuestion",
+  "tags": ["design-system", "developer-tools", "interface", "themes"],
+  "author": {
+    "name": "Phosphor",
+    "github": "its-rosetta",
+    "url": "https://phosphor.co"
+  },
+  "source": {
+    "npm": {
+      "package": "@phosphorco/bb-plugin-bb-ui-reference",
+      "range": "^0.1.0"
+    }
+  }
+}


### PR DESCRIPTION
## What it does

BB UI Reference shows BB's plugin surface map alongside live demonstrations of the active semantic theme palette.

## Release

- npm: `@phosphorco/bb-plugin-bb-ui-reference@0.1.0`
- Marketplace range: `^0.1.0`
- Source: `phosphorco/bb-community-plugins`

## Validation

- Plugin tests, typecheck, BB build, and package inspection passed in the release workflow.
- Marketplace build, liveness check, schema validation, and `git diff --check` passed.

## Permissions and security

BB UI Reference is a full-trust BB plugin. It serves bundled static reference SVGs and reads BB's semantic theme variables; it does not require an external service.
