### PR TITLE
Add Sticky Notes plugin

### DIFF
--- a/entries/sticky-notes.json
+++ b/entries/sticky-notes.json
@@ -1,0 +1,18 @@
+{
+  "id": "sticky-notes",
+  "displayName": "Sticky Notes",
+  "description": "Adds shared, movable notes directly to bb threads for asynchronous collaboration.",
+  "icon": "Note",
+  "tags": ["collaboration", "interface", "notes", "threads"],
+  "author": {
+    "name": "Phosphor",
+    "github": "its-rosetta",
+    "url": "https://phosphor.co"
+  },
+  "source": {
+    "npm": {
+      "package": "@phosphorco/bb-plugin-sticky-notes",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/entries/sticky-notes.json
+++ b/entries/sticky-notes.json
@@ -2,8 +2,15 @@
   "id": "sticky-notes",
   "displayName": "Sticky Notes",
   "description": "Adds shared, movable notes directly to bb threads for asynchronous collaboration.",
-  "icon": "Note",
-  "tags": ["collaboration", "interface", "notes", "threads"],
+  "icon": {
+    "url": "./icons/sticky-notes-5dc1948a.svg"
+  },
+  "tags": [
+    "collaboration",
+    "interface",
+    "notes",
+    "threads"
+  ],
   "author": {
     "name": "Phosphor",
     "github": "its-rosetta",

--- a/icons/sticky-notes-5dc1948a.svg
+++ b/icons/sticky-notes-5dc1948a.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Hugeicons StickyNote01Icon (free set, MIT), vendored for the BB marketplace listing. -->
+  <path d="M12.5 5H11.5C7.72876 5 5.84315 5 4.67157 6.17157C3.5 7.34315 3.5 9.22876 3.5 13V14C3.5 17.7712 3.5 19.6569 4.67157 20.8284C5.84315 22 7.72876 22 11.5 22L12.5 22C16.2712 22 18.1569 22 19.3284 20.8284C20.5 19.6569 20.5 17.7712 20.5 14V13C20.5 9.22876 20.5 7.34315 19.3284 6.17157C18.1569 5 16.2712 5 12.5 5Z" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+  <path d="M11 7.5C11 8.32843 11.6716 9 12.5 9C13.3284 9 14 8.32843 14 7.5V4C14 2.89543 13.1046 2 12 2C10.8954 2 10 2.89543 10 4V5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+  <path d="M7.5 17.5H12.5M7.5 13.5H16.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+</svg>


### PR DESCRIPTION
## What it does

Sticky Notes adds shared, movable notes directly to bb threads for asynchronous collaboration.

## Release

- npm: `@phosphorco/bb-plugin-sticky-notes@0.1.0`
- Marketplace range: `^0.1.0`
- Source: `phosphorco/bb-community-plugins`

## Validation

- Plugin tests, typecheck, BB build, and package inspection passed in the release workflow.
- Marketplace build, liveness check, schema validation, and `git diff --check` passed.

## Permissions and security

Sticky Notes is a full-trust BB plugin. It stores shared notes in plugin-owned SQLite state and renders its collaboration UI within BB; it does not require an external service.
