### PR TITLE
Add plugin entry: bb-rpiv-todo-renderer

### DIFF
--- a/entries/bb-rpiv-todo-renderer.json
+++ b/entries/bb-rpiv-todo-renderer.json
@@ -1,0 +1,20 @@
+{
+  "id": "bb-rpiv-todo-renderer",
+  "displayName": "RPIV Todo",
+  "description": "Renders Pi rpiv-todo tasks in BB's native composer to-do panel.",
+  "icon": {
+    "url": "./icons/bb-rpiv-todo-renderer-3665901c.svg"
+  },
+  "tags": ["interface", "todo", "composer", "pi"],
+  "author": {
+    "name": "Zhen Huang",
+    "github": "ZhenHuangLab",
+    "url": "https://github.com/ZhenHuangLab"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/ZhenHuangLab/bb-rpiv-todo-renderer.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/icons/bb-rpiv-todo-renderer-3665901c.svg
+++ b/icons/bb-rpiv-todo-renderer-3665901c.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="5" width="6" height="6" rx="1" />
+  <path d="m3 17 2 2 4-4" />
+  <path d="M13 6h8" />
+  <path d="M13 12h8" />
+  <path d="M13 18h8" />
+</svg>


### PR DESCRIPTION
## Plugin

RPIV Todo renders Pi `@juicesharp/rpiv-todo` tasks in BB’s native composer to-do panel (`N/M complete`). BB’s first-party extractor only recognizes `TodoWrite` and Claude `Task*` tools; this plugin replays completed `todo` tool-call arguments from the thread timeline and draws the matching chrome.

- Plugin id: `bb-rpiv-todo-renderer`
- Display name: RPIV Todo
- Repo: https://github.com/ZhenHuangLab/bb-rpiv-todo-renderer
- License: MIT
- No extra permissions, network calls, or secrets. Read-only over `bb.sdk.threads.events`.

## Source

- Git: `https://github.com/ZhenHuangLab/bb-rpiv-todo-renderer.git`
- Range: `^0.1.0`
- Release tag: `v0.1.0` → `fbb359814c0e2e5ce1a45de9bde8f1658a44b936`

## Plugin checks

- `npx tsc --noEmit` passed
- `bb plugin build` passed
- Installed locally as `bb-rpiv-todo-renderer@0.1.0` (running)

## Marketplace checks

- `npm run build` — `dist/marketplace.json` with 9 entries
- `npm run check` — liveness against the public `v0.1.0` tag
