### PR TITLE
Add plugin entry: bb-better-latex

### DIFF
--- a/entries/bb-better-latex.json
+++ b/entries/bb-better-latex.json
@@ -1,0 +1,20 @@
+{
+  "id": "bb-better-latex",
+  "displayName": "Better LaTeX",
+  "description": "Renders $...$ and leftover \\[...\\] / \\(...\\) math in BB chat.",
+  "icon": {
+    "url": "./icons/bb-better-latex-8274bdfa.svg"
+  },
+  "tags": ["interface", "latex", "math", "markdown"],
+  "author": {
+    "name": "Zhen Huang",
+    "github": "ZhenHuangLab",
+    "url": "https://github.com/ZhenHuangLab"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/ZhenHuangLab/bb-better-latex.git",
+      "range": "^0.2.2"
+    }
+  }
+}

--- a/icons/bb-better-latex-8274bdfa.svg
+++ b/icons/bb-better-latex-8274bdfa.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M18 5V4H6l6 8-6 8h12v-1" />
+</svg>


### PR DESCRIPTION
## Plugin

Better LaTeX typesets `$...$` and leftover `\[...\]` / `\(...\)` math in BB chat. Stock BB only accepts `$$...$$`; this plugin walks rendered markdown, uses currency-safe heuristics, and reassembles formulas that markdown splits across nodes.

- Plugin id: `bb-better-latex`
- Display name: Better LaTeX
- Repo: https://github.com/ZhenHuangLab/bb-better-latex
- License: MIT
- Frontend content script only. Depends on KaTeX. No extra permissions, network calls, or secrets.

## Source

- Git: `https://github.com/ZhenHuangLab/bb-better-latex.git`
- Range: `^0.2.2`
- Release tag: `v0.2.2` → `77b4fd7b29beb64a9b8a06df5040ac6885374ed8`

## Plugin checks

- `npx tsc --noEmit` passed
- `bb plugin build` passed
- Installed locally as `bb-better-latex@0.2.2` (running)

## Marketplace checks

- `npm run build` — `dist/marketplace.json` with 9 entries
- `npm run check` — liveness against the public `v0.2.2` tag
