### PR TITLE
Add plugin entry: gtd-sidebar

### DIFF
--- a/entries/gtd-sidebar.json
+++ b/entries/gtd-sidebar.json
@@ -1,0 +1,22 @@
+{
+  "id": "gtd-sidebar",
+  "displayName": "GTD Sidebar",
+  "description": "Replaces the bb thread list with an inbox that splits threads into Next Action and Waiting, and clears them with snooze and settle.",
+  "icon": {
+    "url": "./icons/gtd-sidebar-0a2df40e.svg"
+  },
+  "tags": ["interface", "sidebar", "threads", "inbox", "productivity"],
+  "author": {
+    "name": "Scott Sunarto",
+    "github": "smsunarto",
+    "url": "https://github.com/smsunarto"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/smsunarto/bb-plugins.git",
+      "subdir": "plugins/gtd-sidebar",
+      "range": "^0.4.0",
+      "tagPrefix": "gtd-sidebar/"
+    }
+  }
+}

--- a/icons/gtd-sidebar-0a2df40e.svg
+++ b/icons/gtd-sidebar-0a2df40e.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" color="#000">
+  <path d="M13 3H11C7.22876 3 5.34315 3 4.17157 4.17157C3 5.34315 3 7.22876 3 11V13C3 16.7712 3 18.6569 4.17157 19.8284C5.34315 21 7.22876 21 11 21H13C16.7712 21 18.6569 21 19.8284 19.8284C21 18.6569 21 16.7712 21 13V11C21 7.22876 21 5.34315 19.8284 4.17157C18.6569 3 16.7712 3 13 3Z" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+  <path d="M9 3V21" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+</svg>


### PR DESCRIPTION
### What it does

GTD Sidebar replaces bb's scrolling thread list with an inbox organized by who
can act next. Active threads split into **Next Action** when the user can act and
**Waiting** while the agent works, each section oldest first, and a thread holds
its place until its next handoff. Two email verbs clear the list: **snooze** until
a wake time, or **settle** when the work is done — settling also archives the
thread in bb, so every other surface agrees. It is for anyone running enough
concurrent threads that "which of these is waiting on me?" stops being obvious.

Docs: https://github.com/smsunarto/bb-plugins/tree/main/plugins/gtd-sidebar

<img src="https://raw.githubusercontent.com/smsunarto/bb-plugins/ebaf6f0e3456f940ff4b18b8b634061d7953e0b9/plugins/gtd-sidebar/docs/media/hero.png" alt="The GTD Sidebar inbox beside its shelf model: Next Action, Waiting, Snoozed, and Settled" width="100%" />

### Source release

| | |
|---|---|
| Repository | `https://github.com/smsunarto/bb-plugins.git` (public) |
| Subdir | `plugins/gtd-sidebar` |
| Tag prefix | `gtd-sidebar/` |
| Released tag | `gtd-sidebar/v0.4.0` (commit `ebaf6f0`) |
| Entry range | `^0.4.0` |
| Engines (from `package.json`) | `bb >=0.38.0 <0.39.0`, `bbPluginSdk >=0.4.6` |

Multi-plugin repo: releases are tagged per plugin via Changesets, so `tagPrefix`
scopes the semver range to this plugin's tags only. The tag is annotated, pushed,
and never moved.

### Plugin checks

Run from the repo root; `plugins/gtd-sidebar` is byte-identical to the released
tag (`git diff gtd-sidebar/v0.4.0 -- plugins/gtd-sidebar` is empty).

- [x] `bun run build` — plugin builds
- [x] `bun run typecheck` — clean
- [x] `bun test` — 130 passing
- [x] `bun run lint` — clean
- [x] `bun run icons:check` — branding assets intact
- [x] `bun run compatibility:check` — declared bb/SDK ranges still hold
- [x] Exercised end to end on bb 0.38.0 — inbox sections, snooze, settle, the
      project scope picker, and the Appearance setting that selects it. Installed
      from a local path source rather than from the tag; the two trees are
      identical, but I want to be precise about what was tested.

### Marketplace checks

Run in this fork:

- [x] `npm ci && npm run build` — entry validates, `dist/marketplace.json` composes (12 entries)
- [x] `npm run check` — release source resolves; `git ls-remote` finds `gtd-sidebar/v0.4.0` in range
- [x] `id` matches the filename and the id derived from `@smsunarto/bb-plugin-gtd-sidebar`
- [x] No existing entry claims this `id`
- [x] Icon is SVG, 578 bytes, no scripts, no remote or embedded references
- [x] Diff touches only `entries/gtd-sidebar.json` and `icons/gtd-sidebar-0a2df40e.svg`

### Permissions and external services

- Network: none
- Filesystem: none outside the bb data dir
- Processes: none
- Credentials: none
- Platform: cross-platform
- Third-party services: none

### Notes for reviewers

**It uses an experimental SDK slot.** The plugin renders through
`app.slots.experimental_threadList`, which is why `engines.bb` is pinned to the
`0.38.x` line rather than an open-ended range. Installing changes nothing on its
own — bb's own list stays the default until the user picks **GTD Sidebar (inbox)**
under Settings → Appearance → Sidebar, and it comes back the moment they switch
away or disable the plugin.

**Prior art.** This is a fork of bb's own example at
`get-bb/bb` → `examples/plugins/t3sidebar`, commit `f13c2d3` (2026-08-07), with
the upstream MIT notice carried in `THIRD_PARTY_NOTICES.md`. It shipped as
`t3sidebar` through 0.3.0 and was renamed for 0.4.0 precisely to stop colliding
with the existing `entries/t3sidebar.json`; the two are separate plugins with
separate ids and separate state, and neither shadows the other.

**One uninstall caveat, stated plainly.** Shelf state lives in the plugin's own
database, which bb removes with the plugin, but a copy is cached in web
`localStorage` under `gtd-sidebar:v1:*` (thread ids, park timestamps, provider
ids/names/logo paths). bb's uninstall does not clear web storage. No data leaves
the machine either way.
