### PR TITLE
Add Advisor plugin

### DIFF
--- a/entries/advisor.json
+++ b/entries/advisor.json
@@ -2,8 +2,15 @@
   "id": "advisor",
   "displayName": "Advisor",
   "description": "Adds a persistent second-model reviewer to BB coding threads, with tracked findings and fail-closed review status.",
-  "icon": "ShieldCheck",
-  "tags": ["agents", "developer-tools", "quality", "reviews"],
+  "icon": {
+    "url": "./icons/advisor-806f8ae3.svg"
+  },
+  "tags": [
+    "agents",
+    "developer-tools",
+    "quality",
+    "reviews"
+  ],
   "author": {
     "name": "Salem Sayed Abdel Gawad",
     "github": "salemsayed",

--- a/entries/advisor.json
+++ b/entries/advisor.json
@@ -1,0 +1,18 @@
+{
+  "id": "advisor",
+  "displayName": "Advisor",
+  "description": "Adds a persistent second-model reviewer to BB coding threads, with tracked findings and fail-closed review status.",
+  "icon": "ShieldCheck",
+  "tags": ["agents", "developer-tools", "quality", "reviews"],
+  "author": {
+    "name": "Salem Sayed Abdel Gawad",
+    "github": "salemsayed",
+    "url": "https://github.com/salemsayed"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/salemsayed/bb-plugin-advisor.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/icons/advisor-806f8ae3.svg
+++ b/icons/advisor-806f8ae3.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Hugeicons SecurityCheckIcon (free set, MIT), vendored for the BB marketplace listing. -->
+  <path d="M18.7088 3.49534C16.8165 2.55382 14.5009 2 12 2C9.4991 2 7.1835 2.55382 5.29116 3.49534C4.36318 3.95706 3.89919 4.18792 3.4496 4.91378C3 5.63965 3 6.34248 3 7.74814V11.2371C3 16.9205 7.54236 20.0804 10.173 21.4338C10.9067 21.8113 11.2735 22 12 22C12.7265 22 13.0933 21.8113 13.8269 21.4338C16.4576 20.0804 21 16.9205 21 11.2371L21 7.74814C21 6.34249 21 5.63966 20.5504 4.91378C20.1008 4.18791 19.6368 3.95706 18.7088 3.49534Z" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+  <path d="M9 11.5C9 11.5 10.4079 11.7519 11 13.5C11 13.5 12.5 10.5 15 9.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+</svg>


### PR DESCRIPTION
## Summary

- list Advisor in the BB Community marketplace
- install from `salemsayed/bb-plugin-advisor` using the `^0.1.0` release range
- surface the plugin with its `ShieldCheck` icon and review/developer-tool tags

Advisor adds an independent second-model reviewer to BB coding threads. It reviews work before completion, tracks findings across rounds, and reports reviewer failures as unavailable rather than approval.

## Validation

- [x] Advisor typecheck
- [x] Advisor test suite (83 tests)
- [x] Advisor production build
- [x] Advisor package dry run
- [x] Marketplace `npm run build`
- [x] Marketplace `npm run check`

## Security and trust

Advisor is a full-trust BB plugin. Its server can inspect thread and environment state through the plugin SDK and stores review history in plugin-owned SQLite state. Reviewer threads use the narrowest permission mode supported by the configured provider.
