### PR TITLE
Add plugin entry: session-notes

### DIFF
--- a/entries/session-notes.json
+++ b/entries/session-notes.json
@@ -1,0 +1,25 @@
+{
+  "id": "session-notes",
+  "displayName": "Session Notes",
+  "description": "Attaches private, thread-scoped notes to individual bb timeline messages, and never sends them to the agent's context.",
+  "icon": "FileText",
+  "tags": [
+    "notes",
+    "annotations",
+    "threads",
+    "messages",
+    "interface",
+    "markdown"
+  ],
+  "author": {
+    "name": "Pablo Oliva",
+    "github": "pablooliva",
+    "url": "https://github.com/pablooliva"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/pablooliva/bb-ide-session-notes-plugin.git",
+      "range": "^0.1.0"
+    }
+  }
+}


### PR DESCRIPTION
## What the plugin does

Session Notes lets you attach short, private notes to individual user or assistant
messages in a bb thread. Hovering a message reveals an **Add note** action; notes
appear in a **Notes** tab in the thread's right panel, listed in timeline order with
a plain-text excerpt of the message each one is anchored to. Note bodies are authored
as markdown and rendered through bb's own chat renderer; bodies are stored raw, so
rendering is a display concern only.

Notes are deliberately ephemeral: scoped to a single thread, not synced, not exported.
Two settings (`bb plugin config session-notes`) control lifetime — `sweepOnArchive`
(default `true`) deletes a thread's notes when the thread is archived, and
`retentionDays` (default `"off"`, options `1/7/30/90`) runs an hourly age sweep.
Notes are always deleted when a thread is deleted.

## Source release

- Source: git, `https://github.com/pablooliva/bb-ide-session-notes-plugin.git`
- Range: `^0.1.0`, resolving to the annotated tag `v0.1.0` at commit `feba0357`
- Single plugin at the repository root: no `subdir`, no `tagPrefix`
- Not published to npm; a git install builds from source

## Plugin checks

Run from the plugin repository at the tagged commit:

- `tsc --noEmit` — clean
- `vitest run` — 31 tests passed (1 file)
- `bb plugin build .` — emits `dist/server.js`, `dist/app.js`, `dist/app.css`
- Working tree clean at the release commit; `dist/` is gitignored

## Marketplace checks

- `npm run build` — validated, composed `dist/marketplace.json` with 12 entries
- `npm run check` — liveness passed; the `^0.1.0` range resolves against the public
  repository's `v0.1.0` tag
- Entry id `session-notes` matches the filename and the id bb derives from the
  package name `bb-plugin-session-notes`
- `icon` uses the BB host icon name `FileText`, matching the plugin manifest's
  `bb.branding.icon`; no icon file added
- `author.github` is `pablooliva`, the account opening this pull request

## Notes for reviewers: permissions and security

The plugin's core invariant is that note contents never enter a model's context, and
it is enforced by omission rather than by filtering:

- No `bb.agents` tool and no `contributeInstructions` — the two APIs that place
  plugin content into a turn.
- No `skills/` directory. `bb plugin new` scaffolds one; it was removed, because a
  shipped skill is itself agent context.
- Note bodies live only in the plugin's own `data.db`, never in `bb.db`'s event log.
- `server.test.ts` asserts this as a group (`describe("agent isolation")`).

One deliberate exception, called out for review: the plugin registers a `bb note`
CLI command (`add` / `list` / `rm`) so scripts and hooks can drop markers. Because bb
generates a `plugin-commands` skill from registered commands, note-*taking* is
therefore discoverable to agents, and an agent can write a note. Note *contents*
still never enter a model's context. To keep agent-authored notes visible, notes
created via the CLI are stored with role `cli` and the panel labels them
**"via bb note"** instead of **"You"**. There is intentionally no `bb note edit`;
editing is panel-only.

No external services, no network calls, and no credentials. Declared engines are
`bb >=0.38` and `bbPluginSdk >=0.4.6`.
