### PR TITLE
Add Tinted Threads sidebar plugin

### DIFF
--- a/entries/tinted-threads.json
+++ b/entries/tinted-threads.json
@@ -1,0 +1,17 @@
+{
+  "id": "tinted-threads",
+  "displayName": "Tinted Threads",
+  "description": "A tinted replacement for bb's sidebar thread list with active and blocked row hues, provider glyphs, git diff badges, and sub-thread nesting.",
+  "icon": "PanelLeft",
+  "tags": ["interface", "sidebar", "threads"],
+  "author": {
+    "name": "Tom McKenzie",
+    "github": "grrowl"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/grrowl/bb-tinted-threads.git",
+      "range": "^0.1.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a marketplace listing for [Tinted Threads](https://github.com/grrowl/bb-tinted-threads), a replacement sidebar thread list for bb.

- Green row tint while a thread is actively working
- Red row tint when a thread is blocked or in error
- Provider glyphs (Claude, Codex, Cursor, Pi, OpenCode, Hermes) plus git diff badges
- Sub-threads nested beneath their parent with depth indent
- Right-click context menu for thread actions

## Plugin details

- **Plugin id:** `tinted-threads`
- **Source:** `https://github.com/grrowl/bb-tinted-threads.git` with semver range `^0.1.0`
- **Latest release:** v0.1.4
- **Requires:** bb `>=0.38`, plugin SDK `>=0.4.6`

Enable in Settings → Appearance → Sidebar.

## Validation

```sh
npm ci
npm run build
npm run check
```

All passed locally, including git tag liveness for the source repository.


Made with [Cursor](https://cursor.com)