### PR TITLE
Add plugin entry: rephrase

### DIFF
--- a/entries/rephrase.json
+++ b/entries/rephrase.json
@@ -1,0 +1,17 @@
+{
+  "id": "rephrase",
+  "displayName": "Re-phrase",
+  "description": "Adds a Re-phrase button to the prompt input that rewrites your draft with an agent and puts the result back in the composer.",
+  "icon": "AiContentGenerator01",
+  "tags": ["prompt", "composer", "interface", "writing"],
+  "author": {
+    "name": "suiramdev",
+    "github": "suiramdev"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/suiramdev/bb-plugin-rephrase.git",
+      "range": "^0.2.1"
+    }
+  }
+}


### PR DESCRIPTION
## What the plugin does

Re-phrase adds a **Re-phrase** button to the bb prompt input (and the composer `+` menu, for the compact layout). Clicking it sends the draft you already typed to an agent with a rewrite instruction and replaces the draft with the improved prompt; the confirmation toast carries an **Undo** that restores the original text. It works in every composer: thread, queued message, side chat and the new-thread screen.

By default the rewrite runs on the agent already selected in that prompt input; the settings panel offers a searchable model picker to pin one model for every re-phrase. The rewrite instruction and a timeout are host-rendered settings, read per request.

Nothing leaves the path your agent already uses: the rewrite runs through bb in a hidden thread, in the most restrictive permission mode the provider supports, reusing an existing project environment rather than provisioning a worktree, and the thread is stopped and deleted on every path including errors and timeouts.

https://github.com/user-attachments/assets/4e5db258-1af8-4473-8157-efd2134dc056

## Source release

- `git`: `https://github.com/suiramdev/bb-plugin-rephrase.git`, range `^0.2.1`
- Resolved tag `v0.2.1` → commit `957bbc881339473c6606b9c892675bc296bf8a8b`
- Public repository, MIT licensed, single plugin at the repository root (no `subdir`, no `tagPrefix`)
- Plugin id `rephrase`, derived from package name `bb-plugin-rephrase`; matches the entry `id` and the filename

## Plugin checks

Run at the released commit with a clean worktree:

- `npm test` — 26 tests across 3 files pass (composer action, model picker, search rules, server)
- `npm run typecheck` — `tsc --noEmit` clean
- `bb plugin build` — server and app bundles emitted (`dist/server.js`, `dist/app.js`, `dist/app.css`, meta files)

Manifest declares `engines`: `bb >=0.38`, `bbPluginSdk >=0.4.6`.

## Marketplace checks

- `npm ci --ignore-scripts`, `npm run build`, `npm run check` all pass (13 entries; liveness resolves the git source)
- Entry adds only `entries/rephrase.json`; no icon file, so `icon` uses the host icon name `AiContentGenerator01`, the same name as the plugin manifest's `bb.branding.icon`

## Notes for reviewers

- No external services, network calls or API keys of its own: the plugin only talks to bb, which routes to the agent the user already signed in to. The user's draft text is sent to that agent as prompt content.
- Permissions/host surfaces used: composer customization (`app.composer.customize`), one RPC method (`rephrase`), plugin settings, plugin key-value storage for the picked model, and thread create/message/stop/delete for the hidden rewrite thread.
- Model catalogue is built by asking each signed-in agent for its models, which can launch that agent's CLI; results stream in and are cached, so the picker never blocks on it.
