### PR TITLE
Add Checklists plugin

### DIFF
--- a/entries/agent-checklists.json
+++ b/entries/agent-checklists.json
@@ -1,0 +1,20 @@
+{
+  "id": "agent-checklists",
+  "displayName": "Checklists",
+  "description": "Keeps a persisted set of agent-owned steps attached to each BB thread and continues incomplete work automatically.",
+  "icon": "ClipboardCheck",
+  "tags": ["agent-tools", "checklists", "threads", "automation", "productivity"],
+  "author": {
+    "name": "Patrick Lee",
+    "github": "patleeman",
+    "url": "https://github.com/patleeman"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/patleeman/bb-plugins.git",
+      "subdir": "packages/bb-plugin-agent-checklists",
+      "range": "^0.1.0",
+      "tagPrefix": "agent-checklists/"
+    }
+  }
+}


### PR DESCRIPTION
## What this adds

Checklists gives each BB thread a persisted, structured set of agent-owned steps. Agents can read and update steps, notes, and evidence through native tools. The workbench shows progress and the next unchecked steps, while automatic, approval-based, and tracking-only continuation modes control how incomplete work is handled.

## Source

- Repository: https://github.com/patleeman/bb-plugins
- Plugin subdirectory: `packages/bb-plugin-agent-checklists`
- Package/plugin ID: `agent-checklists`
- Display name: `Checklists`
- Release range: `^0.1.0`
- Release tag prefix: `agent-checklists/`

## Validation

- Checklists test suite: 81 tests passing
- TypeScript typecheck passing
- `bb plugin build` passing
- Local BB reload confirms the manifest ID remains `agent-checklists` and the display name is `Checklists`
- Marketplace `npm run build` passing with the new entry
- Marketplace liveness check is pending the public `agent-checklists/v0.1.0` release tag

The plugin uses its existing BB `ClipboardCheck` icon and does not require an external service or secret.
