### PR TITLE
Update Taskboard to v0.2.0

### DIFF
--- a/entries/taskboard.json
+++ b/entries/taskboard.json
@@ -21,7 +21,7 @@
   "source": {
     "npm": {
       "package": "bb-plugin-taskboard",
-      "range": "^0.1.2"
+      "range": "^0.2.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

- allow the Taskboard marketplace entry to resolve the new `0.2.x` feature release

## Release

- npm package: `bb-plugin-taskboard@0.2.0`
- upstream repository: `MateoCerquetella/bb-plugins`
- release tag: `taskboard/v0.2.0`

