### PR TITLE
Add plugin entry: tokyo-night

### DIFF
--- a/entries/tokyo-night.json
+++ b/entries/tokyo-night.json
@@ -1,0 +1,20 @@
+{
+  "id": "tokyo-night",
+  "displayName": "Tokyo Night",
+  "description": "Adds the two Tokyo Night palettes (Night and Storm), each pairing its dark base with Tokyo Night Light for light mode.",
+  "icon": {
+    "url": "./icons/tokyo-night-6c795cf1.svg"
+  },
+  "tags": ["themes", "appearance", "colors", "interface", "tokyo-night"],
+  "author": {
+    "name": "Justin Krehel",
+    "github": "krehel",
+    "url": "https://github.com/krehel"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/krehel/bb-plugin-tokyo-night.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/icons/tokyo-night-6c795cf1.svg
+++ b/icons/tokyo-night-6c795cf1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="Tokyo Night">
+  <rect width="64" height="64" rx="14" fill="#1a1b26"/>
+  <path d="M40.5 41.2a15 15 0 0 1-15.8-24.4 15 15 0 1 0 19.6 20.9 15 15 0 0 1-3.8 3.5z" fill="#7aa2f7"/>
+  <circle cx="45" cy="18" r="2.2" fill="#bb9af7"/>
+  <circle cx="52" cy="27" r="1.5" fill="#7dcfff"/>
+  <circle cx="17" cy="47" r="1.5" fill="#e0af68"/>
+</svg>


### PR DESCRIPTION
Adds a marketplace entry for **Tokyo Night**, a theme-only plugin contributing two bb palettes.

### What it does

Registers two palettes under Settings → Appearance:

| Theme | Dark base |
| --- | --- |
| Tokyo Night | `#1a1b26` |
| Tokyo Night Storm | `#24283b` |

bb resolves light/dark per client, so each palette also carries the upstream Tokyo Night Light (`#d5d6db` / `#343b58`) for light mode. Each stylesheet sets the two anchors (`--canvas`, `--ink`), the accent, the text tiers, and the semantic tokens; the neutral ramp derives from the anchors.

Colors are taken from [tokyo-night/tokyo-night-vscode-theme](https://github.com/tokyo-night/tokyo-night-vscode-theme) (MIT) rather than re-derived, and are credited in the plugin README. The plugin itself is MIT.

### Source

`git:https://github.com/krehel/bb-plugin-tokyo-night.git` with range `^0.1.0`, resolved over repository-wide `vX.Y.Z` tags. Released tag `v0.1.0` (`a5234d1`). No `subdir` or `tagPrefix` — single plugin at the repository root.

### Plugin checks

- `bb plugin build` succeeds.
- Installed from the public tag on macOS: `bb plugin install git:https://github.com/krehel/bb-plugin-tokyo-night.git@v0.1.0` → `tokyo-night@0.1.0 running`. Both palettes appear in `bb theme list` and apply live.
- The tag contains no `dist/` or `node_modules/`; the plugin builds during install.

### Marketplace checks

- `npm ci --ignore-scripts` && `npm run build` — passes, 37 entries.
- `npm run check` (liveness) — passes; the range resolves against the public tag.
- Entry id matches the filename and the id derived from the package name (`bb-plugin-tokyo-night` → `tokyo-night`).
- Icon vendored at `icons/tokyo-night-6c795cf1.svg` (441 B, content-hashed); the entry references no remote URL.

### Security and permissions

- Theme-only. The manifest declares `themes` and a `server` entry; there is no `app` or `host` bundle.
- The server entry writes one log line and returns. It registers no RPC, settings, storage, routes, or background services.
- No runtime dependencies, no network calls, no filesystem or external service access.
- The palettes are static CSS custom-property overrides. The icon is a static SVG with no scripts, remote references, or embedded data.
