### PR TITLE
Add plugin entry: traces

### DIFF
--- a/entries/traces.json
+++ b/entries/traces.json
@@ -1,0 +1,26 @@
+{
+  "id": "traces",
+  "displayName": "Traces",
+  "description": "Indexes local agent session files and opens searchable trajectories with message, tool, error, and provider filters.",
+  "icon": "Activity",
+  "tags": [
+    "traces",
+    "observability",
+    "agent-sessions",
+    "trajectories",
+    "developer-tools"
+  ],
+  "author": {
+    "name": "Patrick Lee",
+    "github": "patleeman",
+    "url": "https://github.com/patleeman"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/patleeman/bb-plugins.git",
+      "subdir": "packages/bb-plugin-traces",
+      "range": "^0.1.0",
+      "tagPrefix": "traces/"
+    }
+  }
+}

--- a/entries/traces.json
+++ b/entries/traces.json
@@ -2,7 +2,9 @@
   "id": "traces",
   "displayName": "Traces",
   "description": "Indexes local agent session files and opens searchable trajectories with message, tool, error, and provider filters.",
-  "icon": "Activity",
+  "icon": {
+    "url": "./icons/traces-9bdd0463.svg"
+  },
   "tags": [
     "traces",
     "observability",

--- a/icons/traces-9bdd0463.svg
+++ b/icons/traces-9bdd0463.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Hugeicons Activity01Icon (free set, MIT), vendored for the BB marketplace listing. -->
+  <path d="M4.31802 19.682C3 18.364 3 16.2426 3 12C3 7.75736 3 5.63604 4.31802 4.31802C5.63604 3 7.75736 3 12 3C16.2426 3 18.364 3 19.682 4.31802C21 5.63604 21 7.75736 21 12C21 16.2426 21 18.364 19.682 19.682C18.364 21 16.2426 21 12 21C7.75736 21 5.63604 21 4.31802 19.682Z" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+  <path d="M7 14L9.79289 11.2071C10.1834 10.8166 10.8166 10.8166 11.2071 11.2071L12.7929 12.7929C13.1834 13.1834 13.8166 13.1834 14.2071 12.7929L17 10" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+</svg>


### PR DESCRIPTION
## Summary

- Add the `traces` plugin to the BB Community marketplace catalog.
- Resolve the plugin from the `traces/v0.1.0` release tag in `patleeman/bb-plugins`.

## Validation

- Traces tests: 36 passed.
- Traces TypeScript check: passed.
- Traces plugin build: passed.
- Marketplace liveness check: passed.

## Privacy

Traces reads the configured local session directories and writes its own derived local index. It does not upload or forward telemetry.
