### PR TITLE
Add plugin entry: prompts

### DIFF
--- a/entries/prompts.json
+++ b/entries/prompts.json
@@ -1,0 +1,29 @@
+{
+  "id": "prompts",
+  "displayName": "Prompts",
+  "description": "Stashes prompts you write while an agent is busy and injects, schedules, or auto-sends them when it next goes idle, alongside a searchable snippet library with {{fill-in}} templates.",
+  "icon": {
+    "url": "./icons/prompts-4e83ddff.svg"
+  },
+  "tags": [
+    "prompts",
+    "queue",
+    "snippets",
+    "templates",
+    "composer",
+    "scheduling",
+    "threads",
+    "productivity"
+  ],
+  "author": {
+    "name": "Vedran Burojević",
+    "github": "vburojevic",
+    "url": "https://github.com/vburojevic"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/vburojevic/bb-plugin-prompts.git",
+      "range": "^0.2.0"
+    }
+  }
+}

--- a/icons/prompts-4e83ddff.svg
+++ b/icons/prompts-4e83ddff.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M5 3.5h14"/>
+  <path d="M5 8h9"/>
+  <path d="M12 12.5v6"/>
+  <path d="m9 15.5 3 3 3-3"/>
+  <rect x="2.5" y="19" width="19" height="2.5" rx="1.25"/>
+</svg>


### PR DESCRIPTION
## What the plugin does

**Prompts** adds a prompt queue and a snippet library to bb, sharing one SQLite
database and one composer row.

- **Queue** — prompts you write while an agent is busy. Inject one into the
  composer, send it to any thread, arm it to fire when the agent next goes
  idle, or book it for a time. Queues are scoped to a thread, a project, or
  everywhere; when a thread is archived or deleted its leftovers move to the
  project's queue rather than vanishing.
- **Snippets** — reusable titled prompts with `{{fill-in}}` tokens, reachable
  from the composer pill, the `+` menu, or an `@`/`~` mention. The plugin also
  mines bb's own prompt history and offers snippets for the prompts you keep
  retyping.
- A **Prompts** nav panel shows every queue at once, plus the snippet library
  and recently used prompts.

Surfaces: two composer pills, the `+` menu, a composer banner while armed
prompts wait, a thread side panel, the nav panel, `@`/`~` mentions, a
`bb prompts …` CLI, and five `prompts_*` agent tools.

## Source release

- `git`: `https://github.com/vburojevic/bb-plugin-prompts.git`
- `range`: `^0.2.0` — resolves the newest matching tag, currently `v0.2.1`
  (`74dd1b1da6bde7cee87b0c92febbb165570fbba2`)
- Repository is public; the plugin lives at the repository root, so no `subdir`
  or `tagPrefix`.
- Plugin id derives to `prompts` from package name `bb-plugin-prompts`, matching
  the entry id and filename.

## Plugin checks

Run at the release commit:

- `npm test` — 130 tests across 8 files, all passing (real SQLite, not mocks)
- `npm run typecheck` — `tsc --noEmit` clean, server and app
- `bb plugin build` — builds `dist/server.js`, `dist/app.js`, `dist/app.css`
  and both `*.meta.json`

## Marketplace checks

- `npm ci --ignore-scripts`
- `npm run build` — schema validation and manifest composition pass
- `npm run check` — passes with liveness, so the git source and the `^0.2.0`
  release resolve from the public repository

## Permissions, services, security

- No network calls, no telemetry, no external services. All state is one SQLite
  file in the plugin's own data directory.
- No credentials or secrets are read or stored.
- The plugin registers a one-minute schedule (`scheduled-send`) that only sweeps
  its own due prompts, and listens for `thread.idle` to deliver armed prompts.
- Sending is deliberately conservative: armed prompts wait out a configurable
  grace period, anything that puts the thread back to work cancels them, a
  failed thread pauses its own queue instead of leaving prompts pending, and
  claims are atomic so a prompt sends exactly once under racing idle events.
- Reads bb's prompt history locally to suggest snippets; this can be turned off
  with the `mineHistory` setting.

Icon is the plugin's own `assets/icon.svg`, vendored as
`icons/prompts-4e83ddff.svg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

