### PR TITLE
Add plugin entry: prompt-enhancer

### DIFF
--- a/entries/prompt-enhancer.json
+++ b/entries/prompt-enhancer.json
@@ -1,0 +1,25 @@
+{
+  "id": "prompt-enhancer",
+  "displayName": "Prompt Enhancer",
+  "description": "Rewrites the composer draft into a clearer prompt through a hidden bb thread, keeping follow-ups short, preserving @mentions and file paths, and offering Undo.",
+  "icon": {
+    "url": "./icons/prompt-enhancer-c9c7e6e9.svg"
+  },
+  "tags": [
+    "composer",
+    "prompt",
+    "writing",
+    "interface",
+    "keyboard-shortcuts"
+  ],
+  "author": {
+    "name": "Vedran Burojević",
+    "github": "vburojevic"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/vburojevic/bb-plugin-prompt-enhancer.git",
+      "range": "^0.2.0"
+    }
+  }
+}

--- a/icons/prompt-enhancer-c9c7e6e9.svg
+++ b/icons/prompt-enhancer-c9c7e6e9.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+     stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- A draft's text lines with a spark rewriting them: the whole plugin in
+       one mark. Outline style to match BB's stroked icon set (1.5 at a 24
+       viewBox). BB renders plugin icons as CSS masks, which key off alpha
+       coverage, so the paint is an opaque literal rather than currentColor,
+       which has no inherited context inside a mask source. -->
+  <path d="M3.25 6h8.25"/>
+  <path d="M3.25 12h17.5"/>
+  <path d="M3.25 18h13.5"/>
+  <path d="M18.25 2.25q0 3.5 3.5 3.5-3.5 0-3.5 3.5 0-3.5-3.5-3.5 3.5 0 3.5-3.5Z" fill="#000"/>
+</svg>


### PR DESCRIPTION
## What it does

Adds a spark action to every bb composer that rewrites the current draft into a
clearer prompt, in place. The rewriter is a hidden bb thread using the provider
of the thread you are drafting in, so there are no API keys and no external
service — nothing leaves the user's bb.

A few things that make it more than a "rewrite this" button:

- **Shape follows the draft.** A one-line ask stays one line; only genuinely
  multi-part work becomes a brief with a `Done when:` list. Follow-ups are
  detected and deliberately kept as follow-ups rather than inflated into
  standalone specs.
- **References are verified, not just requested.** `@mentions`, file paths,
  code spans and URLs are re-extracted from the original and checked against
  the rewrite — using the composer's structured mentions as ground truth — and
  anything dropped is surfaced in a warning toast before sending.
- **Runs belong to the composer scope,** not the mounted component, so a
  rewrite survives switching threads, reloading the window, reloading the
  plugin, and a second window.
- Undo in the success toast; optional Apply/Discard review; per-model reasoning
  level pinned in plugin settings; all motion collapses under
  `prefers-reduced-motion`.

## Source release

- `git` source, `https://github.com/vburojevic/bb-plugin-prompt-enhancer.git`,
  range `^0.2.0` (resolves to the `v0.2.1` tag).
- Repository is public; `v0.1.1`, `v0.2.0` and `v0.2.1` tags are immutable and
  were never moved.
- `dist/` is committed, so a git install needs no npm.
- MIT licensed.

## Plugin checks

- `npm test` — 42/42 passing (pure logic in `lib/`: prompt construction, the
  dropped-reference guard, reveal pacing, adaptive timeouts, composer-scope
  identity, deadline semantics).
- `bb plugin build` — clean; artifacts stamped `pluginId prompt-enhancer`,
  `pluginVersion 0.2.1`, SDK `0.4.6`.
- Installed end-to-end from the public repo into a clean bb instance and
  confirmed running, via both
  `git:…bb-plugin-prompt-enhancer.git@main` and `…@v0.2.1`.

## Marketplace checks

- `npm ci --ignore-scripts`, `npm run build`, `npm run check` all pass
  (37 entries; `--liveness` resolves the git source and range).
- Entry id `prompt-enhancer` matches the filename and the id derived from the
  package manifest.
- Icon is a 711-byte inline SVG, content-hashed, no scripts or remote refs,
  outline style matching bb's stroked icon set and legible at 16px.

## Permissions, services, network

No network access beyond bb itself, no credentials, no external services. The
plugin creates hidden bb threads for the rewrite and stops and deletes each one
as soon as it resolves. It stores only its own settings plus in-flight run rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
