### PR TITLE
Add plugin entry: floating-terminal

### DIFF
--- a/entries/floating-terminal.json
+++ b/entries/floating-terminal.json
@@ -1,0 +1,27 @@
+{
+  "id": "floating-terminal",
+  "displayName": "Floating Terminal",
+  "description": "Adds a draggable terminal window over bb, opened from the sidebar footer or Ctrl+`, with a tab per shell in any project checkout or machine home directory; tabs are persisted, so a reload or a bb restart reattaches to the same shells with their scrollback.",
+  "icon": {
+    "url": "./icons/floating-terminal-1d6d1fd9.svg"
+  },
+  "tags": [
+    "terminal",
+    "shell",
+    "developer-tools",
+    "xterm",
+    "pty",
+    "tabs",
+    "multi-machine"
+  ],
+  "author": {
+    "name": "Vedran Burojevic",
+    "github": "vburojevic"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/vburojevic/bb-plugin-floating-terminal.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/entries/floating-terminal.json
+++ b/entries/floating-terminal.json
@@ -21,7 +21,7 @@
   "source": {
     "git": {
       "url": "https://github.com/vburojevic/bb-plugin-floating-terminal.git",
-      "range": "^0.1.0"
+      "range": "^0.2.0"
     }
   }
 }

--- a/icons/floating-terminal-1d6d1fd9.svg
+++ b/icons/floating-terminal-1d6d1fd9.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+     stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- A window with a tab strip and a shell prompt inside it: the plugin is a
+       floating window of tabbed PTYs, not a terminal pane. Outline style to
+       match BB's stroked icon set (1.5 at a 24 viewBox). BB renders plugin
+       icons as CSS masks, which key off alpha coverage, so the stroke is an
+       opaque literal rather than currentColor, which has no inherited context
+       inside a mask source. -->
+  <rect x="2.75" y="4.75" width="18.5" height="14.5" rx="3"/>
+  <path d="M2.75 9.25h18.5"/>
+  <path d="M6.25 7h3"/>
+  <path d="M7 12.75l2 2-2 2"/>
+  <path d="M12.25 16.75h4.75"/>
+</svg>


### PR DESCRIPTION
## What the plugin does

Adds a draggable terminal window over the bb app, opened from a sidebar footer
action next to Settings or with `` Ctrl+` ``. Each tab is one real PTY, started
in any project checkout or any connected machine's home directory. The open-tab
list is persisted, so closing the window, reloading the app, or restarting bb
reattaches to the same shells with their scrollback intact; a shell that died in
the meantime is dropped rather than left as a dead row.

The empty window and the `+` menu render the same directory picker, ordered
Recent → Projects → Machines. The xterm palette is derived from bb's live theme
tokens, so it follows the app in light and dark.

Screenshots are in the repository README.

## Source release

- `git` source, semver range `^0.1.0`
- Tag `v0.1.0` → commit `d9d42cb00601f24daccf7da198acbca78f94547e`
- Repository: https://github.com/vburojevic/bb-plugin-floating-terminal (public, MIT)
- Prebuilt `dist/` is committed at the tag, so an install needs no build step.

## Plugin checks

- `npm test` — 25 passing (tab reducer, directory ranking/ordering)
- `npm run typecheck` — clean
- `bb plugin build` — clean
- Verified from a fresh clone of `v0.1.0`: `npm install --omit=dev` then
  `bb plugin build` both succeed, so the tag is installable with production
  dependencies only.

## Marketplace checks

- `npm ci --ignore-scripts`
- `npm run build` — 37 entries
- `npm run check` (liveness) — passes; the git source and tag resolve

## Permissions, services, security

- No network access, no external services, no API keys, no settings secrets.
- Uses `bb.sdk.terminals` for PTY sessions, `bb.sdk.hosts` / `bb.sdk.projects`
  to list the directories a shell may start in, and plugin kv storage for the
  tab list, active tab, and recent directories.
- Two plugin settings: terminal font size, and whether `` Ctrl+` `` toggles the
  window.
- Shells run as the user on a machine they have already connected to bb; the
  plugin starts no process the user did not ask for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
