### PR TITLE
Add plugin entry: handoff

### DIFF
--- a/entries/handoff.json
+++ b/entries/handoff.json
@@ -1,0 +1,30 @@
+{
+  "id": "handoff",
+  "displayName": "Handoff",
+  "description": "Moves a whole session between agents and machines in both directions: hands a bb thread's rendered transcript to another provider (optionally on another enrolled machine, carrying uncommitted work as a patch), or adopts a Claude Code, Codex, Gemini CLI or OpenCode session from your terminal as a bb thread in the same directory.",
+  "icon": {
+    "url": "./icons/handoff-8139c689.svg"
+  },
+  "tags": [
+    "handoff",
+    "session",
+    "transcript",
+    "providers",
+    "machines",
+    "claude-code",
+    "codex",
+    "opencode",
+    "agent-tools"
+  ],
+  "author": {
+    "name": "Vedran Burojevic",
+    "github": "vburojevic",
+    "url": "https://github.com/vburojevic"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/vburojevic/bb-plugin-handoff.git",
+      "range": "^0.7.0"
+    }
+  }
+}

--- a/icons/handoff-8139c689.svg
+++ b/icons/handoff-8139c689.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- The plugin's own two-way arrow mark. BB renders plugin icons as CSS
+       masks keyed off alpha coverage, so the stroke is an opaque literal
+       rather than currentColor, which has no inherited context inside a
+       mask source. -->
+  <path d="m16 3 4 4-4 4"/>
+  <path d="M20 7H4"/>
+  <path d="m8 21-4-4 4-4"/>
+  <path d="M4 17h16"/>
+</svg>


### PR DESCRIPTION
## What the plugin does

**Handoff** moves a whole session between agents — and between machines — in both directions.

- **Hand off**: captures a bb thread from bb's provider-independent event log (so it works for every provider), renders a single markdown handoff document (source metadata, an optional briefing written by the outgoing agent, "how to continue" instructions, and the full transcript with tool calls, command output and file changes), uploads it as a project attachment and spawns a new thread on the chosen provider. A per-message **Hand off from here** action scopes the document to the conversation up to that message. Choosing another enrolled machine also captures the source working tree's git state and delivers everything uncommitted as a patch on the target machine, with `git apply --3way` instructions in the document.
- **Adopt**: takes a session that ran *outside* bb in a terminal — Claude Code, Codex CLI, Gemini CLI or OpenCode — and continues it as a bb thread in the same directory, seeded with its history. Works from a pasted session id, a whole resume command, or a browse list per project; `--machine` reads the same stores on another enrolled machine.

Both directions are also available as `bb handoff …` CLI commands and through a bundled `handoff` agent skill.

## Source release

- Repository: <https://github.com/vburojevic/bb-plugin-handoff> (public, MIT)
- Release tag: `v0.7.0` (annotated, at commit `51b0f79`)
- Entry source: git semver `range: "^0.7.0"`, repository root (no `subdir`)

## Plugin checks

- `npm test` — 115 unit tests pass (capture/render, cross-machine transfer planning, adopt engine and per-agent adapters, remote store readers)
- `npm run typecheck` — clean
- `bb plugin build` — builds `dist/server.js` and `dist/app.js` + `app.css`

## Marketplace checks

- `npm ci --ignore-scripts`, `npm run build`, `npm run check` — all pass; the entry composes into `dist/marketplace.json` and the live git source resolves.
- Entry id `handoff` matches the filename and the id derived from the package name `bb-plugin-handoff`.
- `author.github` is `vburojevic`, the account opening this PR.
- Icon is the plugin's own two-way arrow mark, 505 B, content-hashed (`icons/handoff-8139c689.svg`), stroked with an opaque literal so it masks correctly.

## Permissions, services, security

- No external services, no API keys, no network calls. The plugin only talks to the local bb server through the plugin SDK.
- It reads agent session stores under the user's home (`~/.claude`, `~/.codex`, `~/.gemini`, `~/.local/share/opencode`) to find adoptable sessions. Remote discovery uses bb's own host file API plus one short-lived host terminal running POSIX `sh`/`stat`/`find` (and `sqlite3` for OpenCode); every interpolated path is shell-quoted (`shellQuote`, unit-tested against embedded quotes and metacharacters).
- Cross-machine handoff writes one patch file to `/tmp/bb-handoff-<thread>.patch` on the target machine, capped at 2 MB. Nothing is deleted or moved on the source.
- Requires bb >= 0.36 and plugin SDK ^0.4.1 (declared in `engines`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
