### PR TITLE
Add plugin entry: perspectives

### DIFF
--- a/entries/perspectives.json
+++ b/entries/perspectives.json
@@ -1,0 +1,25 @@
+{
+  "id": "perspectives",
+  "displayName": "Perspectives",
+  "description": "Independent expert help and phase-bounded perspective synthesis for bb agents.",
+  "icon": {
+    "url": "./icons/perspectives-88a49dc4.svg"
+  },
+  "tags": [
+    "perspectives",
+    "agents",
+    "experts",
+    "orchestration"
+  ],
+  "author": {
+    "name": "Phosphor",
+    "github": "its-rosetta",
+    "url": "https://phosphor.co"
+  },
+  "source": {
+    "npm": {
+      "package": "@phosphorco/bb-plugin-perspectives",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/icons/perspectives-88a49dc4.svg
+++ b/icons/perspectives-88a49dc4.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Hugeicons UserMultipleIcon (free set, MIT), vendored for the BB marketplace listing. -->
+  <path d="M13 11C13 8.79086 11.2091 7 9 7C6.79086 7 5 8.79086 5 11C5 13.2091 6.79086 15 9 15C11.2091 15 13 13.2091 13 11Z" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+  <path d="M11.0386 7.55773C11.0131 7.37547 11 7.18927 11 7C11 4.79086 12.7909 3 15 3C17.2091 3 19 4.79086 19 7C19 9.20914 17.2091 11 15 11C14.2554 11 13.5584 10.7966 12.9614 10.4423" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+  <path d="M15 21C15 17.6863 12.3137 15 9 15C5.68629 15 3 17.6863 3 21" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+  <path d="M21 17C21 13.6863 18.3137 11 15 11" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+</svg>


### PR DESCRIPTION
## What it does
Adds Perspectives, which provides independent expert help and phase-bounded perspective synthesis for bb agents.

## Source
Published @phosphorco/bb-plugin-perspectives@0.1.0 with npm range ^0.1.0. Manifest engines: bb >=0.37; bbPluginSdk ^0.4.1. Author: Phosphor / its-rosetta.

## Checks
- Public npm tarball SHA-256: 5ee39ee0175ee0a92bd25d1acfc5b787f88373ffc42bf38a15a157e0a7e235e5.
- Marketplace npm ci --ignore-scripts, npm run build, npm run check, and git diff --check passed.
- Plugin tests/typecheck/build and clean BB 0.39 install/smoke/restart/remove/reinstall passed in the retained release lane.

## Permissions and security
Perspectives registers native help and gather_perspectives tools. Its documented hidden planner/workers are instructed to remain read-only; no plugin UI, CLI, or separately configured external service is declared.