### PR TITLE
Add headroom, noema, noisegate, progressive-skill, rtk, security-guidance, unslop plugins

### DIFF
--- a/entries/headroom.json
+++ b/entries/headroom.json
@@ -1,0 +1,24 @@
+{
+  "id": "headroom",
+  "displayName": "Headroom",
+  "description": "Context budget monitoring \u2014 tells agents how much of the model's context window is used and when to summarise or start fresh.",
+  "icon": {
+    "url": "./icons/headroom-ccf7001b.svg"
+  },
+  "tags": [
+    "context",
+    "tokens",
+    "monitoring",
+    "agent-interaction"
+  ],
+  "author": {
+    "name": "prismatic7",
+    "github": "prismatic7"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/prismatic7/bb-plugin-headroom.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/entries/noema.json
+++ b/entries/noema.json
@@ -1,0 +1,24 @@
+{
+  "id": "noema",
+  "displayName": "Noema",
+  "description": "Federated agentic memory \u2014 bridges BB threads into a Noema cortex over its Streamable HTTP MCP endpoint for durable, searchable memory across sessions.",
+  "icon": {
+    "url": "./icons/noema-858265a4.svg"
+  },
+  "tags": [
+    "memory",
+    "mcp",
+    "federation",
+    "agent-interaction"
+  ],
+  "author": {
+    "name": "prismatic7",
+    "github": "prismatic7"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/prismatic7/bb-plugin-noema.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/entries/noisegate.json
+++ b/entries/noisegate.json
@@ -1,0 +1,24 @@
+{
+  "id": "noisegate",
+  "displayName": "Noisegate",
+  "description": "Noise suppression \u2014 detects and suppresses low-signal agent output like acknowledgements and filler so agents stop burning tokens on 'ok' and 'got it'.",
+  "icon": {
+    "url": "./icons/noisegate-d31ed357.svg"
+  },
+  "tags": [
+    "output",
+    "tokens",
+    "filtering",
+    "agent-interaction"
+  ],
+  "author": {
+    "name": "prismatic7",
+    "github": "prismatic7"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/prismatic7/bb-plugin-noisegate.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/entries/progressive-skill.json
+++ b/entries/progressive-skill.json
@@ -1,0 +1,24 @@
+{
+  "id": "progressive-skill",
+  "displayName": "Progressive Skill",
+  "description": "Smart skill index compaction — usage-ranked, budget-capped skill lists so agents load the right skills.",
+  "icon": {
+    "url": "./icons/progressive-skill-2a22ebd1.svg"
+  },
+  "tags": [
+    "skills",
+    "context",
+    "efficiency",
+    "agent-interaction"
+  ],
+  "author": {
+    "name": "prismatic7",
+    "github": "prismatic7"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/prismatic7/bb-plugin-progressive-skill.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/entries/rtk.json
+++ b/entries/rtk.json
@@ -1,0 +1,24 @@
+{
+  "id": "rtk",
+  "displayName": "Rtk",
+  "description": "Rewrite Terminal Kommand \u2014 rewrites shell commands through the rtk CLI proxy for 60-90% token savings on verbose output like builds, tests, and git diffs.",
+  "icon": {
+    "url": "./icons/rtk-9f6bac05.svg"
+  },
+  "tags": [
+    "terminal",
+    "tokens",
+    "shell",
+    "filtering"
+  ],
+  "author": {
+    "name": "prismatic7",
+    "github": "prismatic7"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/prismatic7/bb-plugin-rtk.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/entries/security-guidance.json
+++ b/entries/security-guidance.json
@@ -1,0 +1,24 @@
+{
+  "id": "security-guidance",
+  "displayName": "Security Guidance",
+  "description": "Pattern-matched security warnings for code the agent writes — 25 rules covering unsafe deserialization, injection, XSS, and crypto footguns.",
+  "icon": {
+    "url": "./icons/security-guidance-b34f32ea.svg"
+  },
+  "tags": [
+    "security",
+    "code-quality",
+    "safety",
+    "agent-interaction"
+  ],
+  "author": {
+    "name": "prismatic7",
+    "github": "prismatic7"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/prismatic7/bb-plugin-security-guidance.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/entries/unslop.json
+++ b/entries/unslop.json
@@ -1,0 +1,24 @@
+{
+  "id": "unslop",
+  "displayName": "Unslop",
+  "description": "Anti-slop filtering \u2014 strips overused AI patterns like hedging, filler, and corporate affect from agent output.",
+  "icon": {
+    "url": "./icons/unslop-5d90a179.svg"
+  },
+  "tags": [
+    "output",
+    "filtering",
+    "writing",
+    "agent-interaction"
+  ],
+  "author": {
+    "name": "prismatic7",
+    "github": "prismatic7"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/prismatic7/bb-plugin-unslop.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/icons/headroom-ccf7001b.svg
+++ b/icons/headroom-ccf7001b.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+     stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- A context gauge: a semicircular meter with a needle pointing into the
+       warning zone. Outline style to match BB's stroked icon set (1.5 at a
+       24 viewBox). BB renders plugin icons as CSS masks, which key off alpha
+       coverage, so the stroke is an opaque literal rather than currentColor. -->
+  <path d="M4 16a8 8 0 1 1 16 0"/>
+  <path d="M12 16l3.5-4.5"/>
+  <path d="M8 16h8"/>
+</svg>

--- a/icons/noema-858265a4.svg
+++ b/icons/noema-858265a4.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+     stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- A memory node: a central circle with three linked satellites, evoking a
+       federated memory graph. Outline style to match BB's stroked icon set
+       (1.5 at a 24 viewBox). BB renders plugin icons as CSS masks, which key
+       off alpha coverage, so the stroke is an opaque literal. -->
+  <circle cx="12" cy="12" r="3"/>
+  <circle cx="5" cy="6" r="2"/>
+  <circle cx="19" cy="6" r="2"/>
+  <circle cx="5" cy="18" r="2"/>
+  <path d="M6.5 7.5L10 10.5"/>
+  <path d="M17.5 7.5L14 10.5"/>
+  <path d="M6.5 16.5L10 13.5"/>
+</svg>

--- a/icons/noisegate-d31ed357.svg
+++ b/icons/noisegate-d31ed357.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+     stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- A noise gate: a speaker with a slash through it, signalling suppression
+       of low-signal output. Outline style to match BB's stroked icon set (1.5
+       at a 24 viewBox). BB renders plugin icons as CSS masks, which key off
+       alpha coverage, so the stroke is an opaque literal. -->
+  <path d="M4 9v6h3l4 3V6L7 9H4z"/>
+  <path d="M16 9l5 6"/>
+  <path d="M21 9l-5 6"/>
+</svg>

--- a/icons/progressive-skill-2a22ebd1.svg
+++ b/icons/progressive-skill-2a22ebd1.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+     stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Layered skill index: three stacked cards, the top one highlighted,
+       evoking progressive disclosure of a ranked skill list. Outline style
+       to match BB's stroked icon set (1.5 at a 24 viewBox). BB renders
+       plugin icons as CSS masks, which key off alpha coverage, so the
+       stroke is an opaque literal. -->
+  <path d="M4 4h16v5H4z"/>
+  <path d="M4 10h16v5H4z"/>
+  <path d="M4 16h16v4H4z"/>
+  <path d="M7 6.5h10M7 12.5h10M7 18.5h6"/>
+</svg>

--- a/icons/rtk-9f6bac05.svg
+++ b/icons/rtk-9f6bac05.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+     stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- A terminal prompt: a chevron and a cursor line, evoking a rewritten
+       shell command. Outline style to match BB's stroked icon set (1.5 at a
+       24 viewBox). BB renders plugin icons as CSS masks, which key off alpha
+       coverage, so the stroke is an opaque literal. -->
+  <rect x="3" y="4" width="18" height="16" rx="2"/>
+  <path d="M7 9l3 3-3 3"/>
+  <path d="M13 15h4"/>
+</svg>

--- a/icons/security-guidance-b34f32ea.svg
+++ b/icons/security-guidance-b34f32ea.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+     stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- A shield with a check, evoking security guidance for code the agent
+       writes. Outline style to match BB's stroked icon set (1.5 at a 24
+       viewBox). BB renders plugin icons as CSS masks, which key off alpha
+       coverage, so the stroke is an opaque literal. -->
+  <path d="M12 3l7 3v5c0 4.5-3 8-7 10-4-2-7-5.5-7-10V6l7-3z"/>
+  <path d="M9 12l2 2 4-4"/>
+</svg>

--- a/icons/unslop-5d90a179.svg
+++ b/icons/unslop-5d90a179.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+     stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- A filter funnel with a sparkle, evoking stripping filler from text.
+       Outline style to match BB's stroked icon set (1.5 at a 24 viewBox). BB
+       renders plugin icons as CSS masks, which key off alpha coverage, so the
+       stroke is an opaque literal. -->
+  <path d="M4 5h16l-6 7v6l-4 2v-8L4 5z"/>
+  <path d="M18 3l.8 1.7L20.5 5.5l-1.7.8L18 8l-.8-1.7-1.7-.8 1.7-.8L18 3z"/>
+</svg>


### PR DESCRIPTION
## Summary

Adds seven BB plugins to the community marketplace:

| Plugin | Description |
|---|---|
| **headroom** | Context budget monitoring — tells agents how much of the model's context window is used and when to summarise or start fresh. |
| **noema** | Federated agentic memory — bridges BB threads into a Noema cortex over its Streamable HTTP MCP endpoint. |
| **noisegate** | Noise suppression — detects and suppresses low-signal agent output like acknowledgements and filler. |
| **progressive-skill** | Smart skill index compaction — usage-ranked, budget-capped skill lists so agents load the right skills. |
| **rtk** | Rewrite Terminal Kommand — rewrites shell commands through the rtk CLI proxy for 60-90% token savings on verbose output. |
| **security-guidance** | Pattern-matched security warnings for code the agent writes — 25 rules covering unsafe deserialization, injection, XSS, and crypto footguns. |
| **unslop** | Anti-slop filtering — strips overused AI patterns like hedging, filler, and corporate affect from agent output. |

## Changes

- `entries/headroom.json`, `entries/noema.json`, `entries/noisegate.json`, `entries/progressive-skill.json`, `entries/rtk.json`, `entries/security-guidance.json`, `entries/unslop.json`
- `icons/headroom-ccf7001b.svg`, `icons/noema-858265a4.svg`, `icons/noisegate-d31ed357.svg`, `icons/progressive-skill-2a22ebd1.svg`, `icons/rtk-9f6bac05.svg`, `icons/security-guidance-b34f32ea.svg`, `icons/unslop-5d90a179.svg`

## Validation

- `npm run build` passes (43 entries).
- All seven source repos are public with `v0.1.0` tags:
  - https://github.com/prismatic7/bb-plugin-headroom
  - https://github.com/prismatic7/bb-plugin-noema
  - https://github.com/prismatic7/bb-plugin-noisegate
  - https://github.com/prismatic7/bb-plugin-progressive-skill
  - https://github.com/prismatic7/bb-plugin-rtk
  - https://github.com/prismatic7/bb-plugin-security-guidance
  - https://github.com/prismatic7/bb-plugin-unslop

Note: `npm run check` (liveness) fails on two unrelated upstream entries (`agent-checklists`, `monokai`) due to transient network errors connecting to github.com — not on the entries in this PR.
