### PR TITLE
Add plugin entry: worktree-setup

### DIFF
--- a/entries/worktree-setup.json
+++ b/entries/worktree-setup.json
@@ -1,0 +1,17 @@
+{
+  "id": "worktree-setup",
+  "displayName": "Worktree Setup",
+  "description": "Runs per-repo setup scripts when bb creates a worktree, using a global git post-checkout hook so nothing needs to live in your repositories.",
+  "icon": "Wrench",
+  "tags": ["worktree", "git-hooks", "provisioning", "setup", "automation"],
+  "author": {
+    "name": "Kavii Suri",
+    "github": "KaviiSuri"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/KaviiSuri/bb-plugin-worktree-setup.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/entries/worktree-setup.json
+++ b/entries/worktree-setup.json
@@ -2,8 +2,16 @@
   "id": "worktree-setup",
   "displayName": "Worktree Setup",
   "description": "Runs per-repo setup scripts when bb creates a worktree, using a global git post-checkout hook so nothing needs to live in your repositories.",
-  "icon": "Wrench",
-  "tags": ["worktree", "git-hooks", "provisioning", "setup", "automation"],
+  "icon": {
+    "url": "./icons/worktree-setup-304ff34c.svg"
+  },
+  "tags": [
+    "worktree",
+    "git-hooks",
+    "provisioning",
+    "setup",
+    "automation"
+  ],
   "author": {
     "name": "Kavii Suri",
     "github": "KaviiSuri"

--- a/icons/worktree-setup-304ff34c.svg
+++ b/icons/worktree-setup-304ff34c.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Hugeicons Wrench01Icon (free set, MIT), vendored for the BB marketplace listing. -->
+  <path d="M20.3584 13.3567C19.1689 14.546 16.9308 14.4998 13.4992 14.4998C11.2914 14.4998 9.50138 12.7071 9.50024 10.4993C9.50024 7.07001 9.454 4.83065 10.6435 3.64138C11.8329 2.45212 12.3583 2.50027 17.6274 2.50027C18.1366 2.49809 18.3929 3.11389 18.0329 3.47394L15.3199 6.18714C14.6313 6.87582 14.6294 7.99233 15.3181 8.68092C16.0068 9.36952 17.1234 9.36959 17.8122 8.68109L20.5259 5.96855C20.886 5.60859 21.5019 5.86483 21.4997 6.37395C21.4997 11.6422 21.5479 12.1675 20.3584 13.3567Z" stroke="currentColor" stroke-width="1.5"/>
+  <path d="M13.5 14.5L7.32842 20.6716C6.22386 21.7761 4.433 21.7761 3.32843 20.6716C2.22386 19.567 2.22386 17.7761 3.32843 16.6716L9.5 10.5" stroke="currentColor" stroke-linecap="round" stroke-width="1.5"/>
+  <path d="M5.50896 18.5H5.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+</svg>


### PR DESCRIPTION
## What it does

Worktree Setup runs a per-repo setup script whenever bb creates a worktree. bb makes worktrees with plain `git worktree add`, which only checks out tracked files, so a fresh worktree has no `.env.local` and an empty `node_modules`. bb's built-in answer is a committed `.bb-env-setup.sh` at the repo root. I wrote this for the case where you don't want that file in git at all.

It installs a git `post-checkout` dispatcher at `~/.githooks` and points global `core.hooksPath` there, so the hook fires during provisioning and runs your script from `~/.bb-setup/<repo>.sh`. Nothing gets written into your repositories. The thread panel and settings section show repo, branch, and hook status, let you edit the script and read its log, and flag the one failure mode that actually bites. husky rewrites `core.hooksPath` back to `.husky/_` on every `npm install`, which quietly stops worktree setup while husky keeps working. That drift gets a one-click repair. A non-zero exit from your script fails `git worktree add` rather than leaving you in a half-built worktree.

## Source

- Repo: `https://github.com/KaviiSuri/bb-plugin-worktree-setup.git` (public, MIT)
- Range `^0.1.0`, resolving to tag `v0.1.0` at commit `96cc9b8`
- Single plugin at the repo root. No `subdir`, no `tagPrefix`.
- Plugin id `worktree-setup`, derived from package `bb-plugin-worktree-setup`; matches the entry id and filename.

## Plugin checks

At the tagged commit, working tree clean, `dist/` committed:

- `tsc --noEmit` clean
- `bb plugin build` clean, emits `dist/server.js`, `dist/app.js`, `dist/app.css` (built with bb 0.38.0, `@get-bb/plugin-sdk` 0.4.6)
- No automated test suite yet. I exercised it by hand in bb 0.38.0: ran `bb plugin dev`, set up hooks from the settings panel, created a worktree and watched the script run and log, then triggered the husky drift and used the repair.

Manifest engines: `bb >=0.35`, `bbPluginSdk >=0.4.6`.

## Marketplace checks

- `npm ci --ignore-scripts`, `npm run build`, `npm run check` all pass (37 entries; liveness resolves the `v0.1.0` tag)
- Diff adds only `entries/worktree-setup.json`
- `icon` is the host name `Wrench`, matching the plugin manifest's `bb.branding.icon`; no icon file
- `author.github` is `KaviiSuri`, the account opening this PR

## Permissions and security

The plugin only touches git hook config and files under your home directory, and only after you click **Set up git hooks**.

- Writes the dispatcher to `~/.githooks` and sets global `core.hooksPath`. In husky repos it also sets the local `core.hooksPath`, which is what the drift check watches.
- Setup scripts and logs live in `~/.bb-setup/`. No repository files are modified.
- No network, no telemetry, no credentials.
- POSIX only, the dispatcher is bash. One machine only. Repo discovery uses the bb server's home directory.
