### PR TITLE
Add plugin entry: callstack

### DIFF
--- a/entries/callstack.json
+++ b/entries/callstack.json
@@ -1,0 +1,27 @@
+{
+  "id": "callstack",
+  "displayName": "Call Stacks",
+  "description": "Agents publish call-stack flow diagrams — types moving through calls, with conditions, loops, and before/after change markers — into a live thread panel with tree, diagram, and swimlane views, drift tracking against the workspace, inline code snippets, and diffs.",
+  "icon": "Layers",
+  "tags": [
+    "call-stack",
+    "diagrams",
+    "types",
+    "code-review",
+    "planning",
+    "agent-tools",
+    "threads",
+    "visualization"
+  ],
+  "author": {
+    "name": "Ethan Greenfeld",
+    "github": "ebg1223",
+    "url": "https://github.com/ebg1223"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/ebg1223/bb-plugin-callstack.git",
+      "range": "^0.3.0"
+    }
+  }
+}


### PR DESCRIPTION
## What the plugin does

Call-stack-driven development for BB. Agents publish "flow" documents — call trees with types on every edge, plus conditions, loops, module lanes, and before/after change markers — via a `callstack_publish` agent tool. A thread panel renders them live in three views (nested tree, tidy-tree diagram with semantic zoom and collapsible subtrees, and a swimlane sequence view), with cross-flow convergence, file-hash drift tracking against the workspace, automatic loc re-anchoring, inline code snippets, and real diffs rendered with `@pierre/diffs`. Publish results include lint warnings (unreadable locs, fn-not-in-file, stale lines, status contradictions, near-duplicate names) so agents self-correct.

## Source

- Repository: https://github.com/ebg1223/bb-plugin-callstack
- Release: git semver range `^0.3.0` (tags v0.1.0–v0.3.0 published; single plugin at repo root)

## Plugin checks

- `tsc --noEmit` clean
- 10 vitest tests pass (`@get-bb/plugin-sdk/testing` fake host: publish/lint/archive/drift/CLI round trips)
- `bb plugin build` succeeds; installed and exercised as a path install

## Marketplace checks

- `npm run build` and `npm run check` pass (45 entries)

## Security notes for reviewers

- Reads workspace files only through `bb.sdk.files` with `rootPath` confinement; agent-supplied loc paths are validated (no absolute paths or `..` traversal)
- No external services, no secrets, no HTTP routes; storage is the plugin's own SQLite
- Background work: one daily auto-archive schedule and thread-lifecycle event handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
