### PR TITLE
Add plugin entry: autorouter

### DIFF
--- a/entries/autorouter.json
+++ b/entries/autorouter.json
@@ -1,0 +1,18 @@
+{
+  "id": "autorouter",
+  "displayName": "Autorouter",
+  "description": "Routes new BB threads using task difficulty, live provider quota, benchmark capability, and a configurable cost preference.",
+  "icon": "Route",
+  "tags": ["routing", "models", "agents", "automation", "cost-control"],
+  "author": {
+    "name": "Jacob Miller",
+    "github": "jjcm",
+    "url": "https://github.com/jjcm"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/jjcm/bb-plugin-autorouter.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/entries/autorouter.json
+++ b/entries/autorouter.json
@@ -1,9 +1,15 @@
 {
   "id": "autorouter",
   "displayName": "Autorouter",
-  "description": "Routes new BB threads using task difficulty, live provider quota, benchmark capability, and a configurable cost preference.",
-  "icon": "Route",
-  "tags": ["routing", "models", "agents", "automation", "cost-control"],
+  "description": "Routes new BB threads using task difficulty, live provider quota, benchmark capability, and a configurable cost preference. Each submission first runs a short hidden classification turn on one of your installed providers, which may not be the one the thread ends up on.",
+  "icon": "Workflow",
+  "tags": [
+    "routing",
+    "models",
+    "agents",
+    "automation",
+    "cost-control"
+  ],
   "author": {
     "name": "Jacob Miller",
     "github": "jjcm",
@@ -12,7 +18,7 @@
   "source": {
     "git": {
       "url": "https://github.com/jjcm/bb-plugin-autorouter.git",
-      "range": "^0.1.0"
+      "range": "^0.2.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add Autorouter to the BB Community marketplace
- Source releases from the public `jjcm/bb-plugin-autorouter` repository using the `^0.1.0` Git tag range
- Describe its difficulty-, quota-, benchmark-, and cost-aware model routing

## Test plan
- [x] Run `npm run build`
- [x] Run `npm run check`
- [x] Verify public `v0.1.0` tag resolves to the release commit


Made with [Cursor](https://cursor.com)