### PR TITLE
Add headroom plugin

### DIFF
--- a/entries/headroom.json
+++ b/entries/headroom.json
@@ -1,0 +1,24 @@
+{
+  "id": "headroom",
+  "displayName": "Headroom",
+  "description": "Context budget monitoring — tells agents how much of the model's context window is used (real usage events, not estimates) and when to summarise or start fresh.",
+  "icon": {
+    "url": "./icons/headroom-ccf7001b.svg"
+  },
+  "tags": [
+    "context",
+    "tokens",
+    "monitoring",
+    "agent-interaction"
+  ],
+  "author": {
+    "name": "prismatic7",
+    "github": "prismatic7"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/prismatic7/bb-plugin-headroom.git",
+      "range": "^0.2.0"
+    }
+  }
+}

--- a/icons/headroom-ccf7001b.svg
+++ b/icons/headroom-ccf7001b.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+     stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- A context gauge: a semicircular meter with a needle pointing into the
+       warning zone. Outline style to match BB's stroked icon set (1.5 at a
+       24 viewBox). BB renders plugin icons as CSS masks, which key off alpha
+       coverage, so the stroke is an opaque literal rather than currentColor. -->
+  <path d="M4 16a8 8 0 1 1 16 0"/>
+  <path d="M12 16l3.5-4.5"/>
+  <path d="M8 16h8"/>
+</svg>


### PR DESCRIPTION
Adds the **headroom** plugin entry.

Addresses review feedback from #60:
- Reads real context usage from `thread/contextWindowUsage/updated` events (fallback: conversation outline message count) — no more broken `e.role` filtering that always reported 0 messages
- Uses `providerId` for the provider name
- Background monitor logs warning thresholds (log-only, as documented)
- Settings re-read via `onChange` — no plugin reload needed

Range: `^0.2.0` (v0.2.0 tagged on prismatic7/bb-plugin-headroom).