### PR TITLE
Add noema plugin

### DIFF
--- a/entries/noema.json
+++ b/entries/noema.json
@@ -1,0 +1,24 @@
+{
+  "id": "noema",
+  "displayName": "Noema",
+  "description": "Bridges BB threads to your own Noema server over its Streamable HTTP MCP endpoint for durable, searchable memory across sessions.",
+  "icon": {
+    "url": "./icons/noema-858265a4.svg"
+  },
+  "tags": [
+    "memory",
+    "mcp",
+    "federation",
+    "agent-interaction"
+  ],
+  "author": {
+    "name": "prismatic7",
+    "github": "prismatic7"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/prismatic7/bb-plugin-noema.git",
+      "range": "^0.2.0"
+    }
+  }
+}

--- a/icons/noema-858265a4.svg
+++ b/icons/noema-858265a4.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+     stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- A memory node: a central circle with three linked satellites, evoking a
+       federated memory graph. Outline style to match BB's stroked icon set
+       (1.5 at a 24 viewBox). BB renders plugin icons as CSS masks, which key
+       off alpha coverage, so the stroke is an opaque literal. -->
+  <circle cx="12" cy="12" r="3"/>
+  <circle cx="5" cy="6" r="2"/>
+  <circle cx="19" cy="6" r="2"/>
+  <circle cx="5" cy="18" r="2"/>
+  <path d="M6.5 7.5L10 10.5"/>
+  <path d="M17.5 7.5L14 10.5"/>
+  <path d="M6.5 16.5L10 13.5"/>
+</svg>


### PR DESCRIPTION
Adds the **noema** plugin entry.

Addresses review feedback from #60:
- Dropped the unwired `noemaCortex` setting (was read but never sent to the server)
- Description now states it bridges to **your own** Noema server (default http://127.0.0.1:3004), not a hosted service
- Settings re-read via `onChange` — no plugin reload needed

Range: `^0.2.0` (v0.2.0 tagged on prismatic7/bb-plugin-noema).