### PR TITLE
Add noisegate plugin

### DIFF
--- a/entries/noisegate.json
+++ b/entries/noisegate.json
@@ -1,0 +1,24 @@
+{
+  "id": "noisegate",
+  "displayName": "Noisegate",
+  "description": "Agent-invoked noise suppression — the agent can check short acknowledgements and filler against known noise patterns before sending.",
+  "icon": {
+    "url": "./icons/noisegate-d31ed357.svg"
+  },
+  "tags": [
+    "output",
+    "tokens",
+    "filtering",
+    "agent-interaction"
+  ],
+  "author": {
+    "name": "prismatic7",
+    "github": "prismatic7"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/prismatic7/bb-plugin-noisegate.git",
+      "range": "^0.2.0"
+    }
+  }
+}

--- a/icons/noisegate-d31ed357.svg
+++ b/icons/noisegate-d31ed357.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+     stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- A noise gate: a speaker with a slash through it, signalling suppression
+       of low-signal output. Outline style to match BB's stroked icon set (1.5
+       at a 24 viewBox). BB renders plugin icons as CSS masks, which key off
+       alpha coverage, so the stroke is an opaque literal. -->
+  <path d="M4 9v6h3l4 3V6L7 9H4z"/>
+  <path d="M16 9l5 6"/>
+  <path d="M21 9l-5 6"/>
+</svg>


### PR DESCRIPTION
Adds the **noisegate** plugin entry.

Addresses review feedback from #60:
- BB has no hook to intercept agent output, so this is now described honestly: an agent-invoked tool (`noisegate_suppress`) the agent can call on its own text — not automatic suppression
- Custom noise phrases are now actually checked (previously parsed but never consulted)
- Settings re-read via `onChange` — no plugin reload needed

Range: `^0.2.0` (v0.2.0 tagged on prismatic7/bb-plugin-noisegate).