### PR TITLE
Add progressive-skill plugin

### DIFF
--- a/entries/progressive-skill.json
+++ b/entries/progressive-skill.json
@@ -1,0 +1,24 @@
+{
+  "id": "progressive-skill",
+  "displayName": "Progressive Skill",
+  "description": "Smart skill index compaction — usage-ranked, budget-capped skill lists so agents load the right skills.",
+  "icon": {
+    "url": "./icons/progressive-skill-2a22ebd1.svg"
+  },
+  "tags": [
+    "skills",
+    "context",
+    "efficiency",
+    "agent-interaction"
+  ],
+  "author": {
+    "name": "prismatic7",
+    "github": "prismatic7"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/prismatic7/bb-plugin-progressive-skill.git",
+      "range": "^0.2.0"
+    }
+  }
+}

--- a/icons/progressive-skill-2a22ebd1.svg
+++ b/icons/progressive-skill-2a22ebd1.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+     stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Layered skill index: three stacked cards, the top one highlighted,
+       evoking progressive disclosure of a ranked skill list. Outline style
+       to match BB's stroked icon set (1.5 at a 24 viewBox). BB renders
+       plugin icons as CSS masks, which key off alpha coverage, so the
+       stroke is an opaque literal. -->
+  <path d="M4 4h16v5H4z"/>
+  <path d="M4 10h16v5H4z"/>
+  <path d="M4 16h16v4H4z"/>
+  <path d="M7 6.5h10M7 12.5h10M7 18.5h6"/>
+</svg>


### PR DESCRIPTION
Adds the **progressive-skill** plugin entry.

Addressed review feedback from #60: settings now re-read via `onChange` — no plugin reload needed.

Range: `^0.2.0` (v0.2.0 tagged on prismatic7/bb-plugin-progressive-skill).