### PR TITLE
Add rtk plugin

### DIFF
--- a/entries/rtk.json
+++ b/entries/rtk.json
@@ -1,0 +1,24 @@
+{
+  "id": "rtk",
+  "displayName": "Rtk",
+  "description": "Agent-invoked shell tool — rewrites commands through the external rtk CLI for filtered output on verbose builds, tests, and git diffs. Requires the rtk CLI; unrestricted shell access.",
+  "icon": {
+    "url": "./icons/rtk-9f6bac05.svg"
+  },
+  "tags": [
+    "terminal",
+    "tokens",
+    "shell",
+    "filtering"
+  ],
+  "author": {
+    "name": "prismatic7",
+    "github": "prismatic7"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/prismatic7/bb-plugin-rtk.git",
+      "range": "^0.2.0"
+    }
+  }
+}

--- a/icons/rtk-9f6bac05.svg
+++ b/icons/rtk-9f6bac05.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+     stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- A terminal prompt: a chevron and a cursor line, evoking a rewritten
+       shell command. Outline style to match BB's stroked icon set (1.5 at a
+       24 viewBox). BB renders plugin icons as CSS masks, which key off alpha
+       coverage, so the stroke is an opaque literal. -->
+  <rect x="3" y="4" width="18" height="16" rx="2"/>
+  <path d="M7 9l3 3-3 3"/>
+  <path d="M13 15h4"/>
+</svg>


### PR DESCRIPTION
Adds the **rtk** plugin entry.

Addresses review feedback from #60:
- Both `exec` calls now set `cwd` to the project directory (resolved via `bb.sdk.projects.get` local_path source) — commands no longer run in the bb server process cwd
- Default `rtkPath` auto-detects via `which rtk` with a clear "rtk not installed at <path>" message on failure (no more macOS-only default)
- Description rewording: only affects commands the agent sends through `rtk_shell`; built-in terminal untouched; entry states it requires the external `rtk` CLI and is an unrestricted shell tool
- Settings re-read via `onChange` — no plugin reload needed

Range: `^0.2.0` (v0.2.0 tagged on prismatic7/bb-plugin-rtk).
