### PR TITLE
Add security-guidance plugin

### DIFF
--- a/entries/security-guidance.json
+++ b/entries/security-guidance.json
@@ -1,0 +1,24 @@
+{
+  "id": "security-guidance",
+  "displayName": "Security Guidance",
+  "description": "Pattern-matched security warnings for code the agent writes — 25 rules covering unsafe deserialization, injection, XSS, and crypto footguns.",
+  "icon": {
+    "url": "./icons/security-guidance-b34f32ea.svg"
+  },
+  "tags": [
+    "security",
+    "code-quality",
+    "safety",
+    "agent-interaction"
+  ],
+  "author": {
+    "name": "prismatic7",
+    "github": "prismatic7"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/prismatic7/bb-plugin-security-guidance.git",
+      "range": "^0.2.0"
+    }
+  }
+}

--- a/icons/security-guidance-b34f32ea.svg
+++ b/icons/security-guidance-b34f32ea.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+     stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- A shield with a check, evoking security guidance for code the agent
+       writes. Outline style to match BB's stroked icon set (1.5 at a 24
+       viewBox). BB renders plugin icons as CSS masks, which key off alpha
+       coverage, so the stroke is an opaque literal. -->
+  <path d="M12 3l7 3v5c0 4.5-3 8-7 10-4-2-7-5.5-7-10V6l7-3z"/>
+  <path d="M9 12l2 2 4-4"/>
+</svg>


### PR DESCRIPTION
Adds the **security-guidance** plugin entry.

Addresses review feedback from #60:
- `bb.branding.icon` changed from `Shield` (not in BB's host icon set, rendered as generic Zap) to the valid host glyph `Lock`
- Settings re-read via `onChange` — no plugin reload needed

Range: `^0.2.0` (v0.2.0 tagged on prismatic7/bb-plugin-security-guidance).
