### PR TITLE
Add unslop plugin

### DIFF
--- a/entries/unslop.json
+++ b/entries/unslop.json
@@ -1,0 +1,24 @@
+{
+  "id": "unslop",
+  "displayName": "Unslop",
+  "description": "Agent-invoked filter — the agent can strip overused AI patterns like hedging, filler, and corporate affect from text before sending.",
+  "icon": {
+    "url": "./icons/unslop-5d90a179.svg"
+  },
+  "tags": [
+    "output",
+    "filtering",
+    "writing",
+    "agent-interaction"
+  ],
+  "author": {
+    "name": "prismatic7",
+    "github": "prismatic7"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/prismatic7/bb-plugin-unslop.git",
+      "range": "^0.2.0"
+    }
+  }
+}

--- a/icons/unslop-5d90a179.svg
+++ b/icons/unslop-5d90a179.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+     stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- A filter funnel with a sparkle, evoking stripping filler from text.
+       Outline style to match BB's stroked icon set (1.5 at a 24 viewBox). BB
+       renders plugin icons as CSS masks, which key off alpha coverage, so the
+       stroke is an opaque literal. -->
+  <path d="M4 5h16l-6 7v6l-4 2v-8L4 5z"/>
+  <path d="M18 3l.8 1.7L20.5 5.5l-1.7.8L18 8l-.8-1.7-1.7-.8 1.7-.8L18 3z"/>
+</svg>


### PR DESCRIPTION
Adds the **unslop** plugin entry.

Addresses review feedback from #60:
- Removed the dead no-op line (server.ts:105-107) — the no-op `replace(/^\s+/gm, (m) => m)` regex
- Description now states it is an agent-invoked tool (BB has no hook to intercept output); only text explicitly passed to `unslop_filter` is affected
- Settings re-read via `onChange` — no plugin reload needed

Range: `^0.2.0` (v0.2.0 tagged on prismatic7/bb-plugin-unslop).
