### PR TITLE
Use GitBranch icon for worktree-setup

### DIFF
--- a/entries/worktree-setup.json
+++ b/entries/worktree-setup.json
@@ -2,9 +2,7 @@
   "id": "worktree-setup",
   "displayName": "Worktree Setup",
   "description": "Runs per-repo setup scripts when bb creates a worktree, using a global git post-checkout hook so nothing needs to live in your repositories.",
-  "icon": {
-    "url": "./icons/worktree-setup-304ff34c.svg"
-  },
+  "icon": "Terminal",
   "tags": [
     "worktree",
     "git-hooks",

--- a/entries/worktree-setup.json
+++ b/entries/worktree-setup.json
@@ -2,7 +2,7 @@
   "id": "worktree-setup",
   "displayName": "Worktree Setup",
   "description": "Runs per-repo setup scripts when bb creates a worktree, using a global git post-checkout hook so nothing needs to live in your repositories.",
-  "icon": "Terminal",
+  "icon": "GitBranch",
   "tags": [
     "worktree",
     "git-hooks",

--- a/icons/worktree-setup-304ff34c.svg
+++ b/icons/worktree-setup-304ff34c.svg
@@ -1,6 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-  <!-- Hugeicons Wrench01Icon (free set, MIT), vendored for the BB marketplace listing. -->
-  <path d="M20.3584 13.3567C19.1689 14.546 16.9308 14.4998 13.4992 14.4998C11.2914 14.4998 9.50138 12.7071 9.50024 10.4993C9.50024 7.07001 9.454 4.83065 10.6435 3.64138C11.8329 2.45212 12.3583 2.50027 17.6274 2.50027C18.1366 2.49809 18.3929 3.11389 18.0329 3.47394L15.3199 6.18714C14.6313 6.87582 14.6294 7.99233 15.3181 8.68092C16.0068 9.36952 17.1234 9.36959 17.8122 8.68109L20.5259 5.96855C20.886 5.60859 21.5019 5.86483 21.4997 6.37395C21.4997 11.6422 21.5479 12.1675 20.3584 13.3567Z" stroke="currentColor" stroke-width="1.5"/>
-  <path d="M13.5 14.5L7.32842 20.6716C6.22386 21.7761 4.433 21.7761 3.32843 20.6716C2.22386 19.567 2.22386 17.7761 3.32843 16.6716L9.5 10.5" stroke="currentColor" stroke-linecap="round" stroke-width="1.5"/>
-  <path d="M5.50896 18.5H5.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
-</svg>


### PR DESCRIPTION
## What this changes

The merged listing used a checked-in Wrench SVG. BB already has a `GitBranch` host icon, so this switches the entry to that built-in icon and removes the now-unused SVG.

## Source release

- The plugin's `v0.1.1` release is live at `https://github.com/KaviiSuri/bb-plugin-worktree-setup.git`.
- The existing marketplace range, `^0.1.0`, includes `v0.1.1`; this PR does not change the source or release range.

## Validation

- `npm run build` passed with 44 entries.
- `npm run check` passed, including git liveness for the plugin source.
- `git diff --check` passed.

This PR changes only the marketplace entry and removes its unused icon file. No plugin code or permissions changed.
