### PR TITLE
Add plugin entry: thread-namer

### DIFF
--- a/entries/thread-namer.json
+++ b/entries/thread-namer.json
@@ -1,0 +1,18 @@
+{
+  "id": "thread-namer",
+  "displayName": "Thread Namer",
+  "description": "Names threads with an agent when their first turn ends, so the sidebar reads as what you were doing, and re-generates a name on demand from the thread header or the CLI.",
+  "icon": "AiContentGenerator01",
+  "tags": ["thread", "title", "naming", "sidebar", "agent", "interface"],
+  "author": {
+    "name": "Marius Nouchet",
+    "github": "suiramdev",
+    "url": "https://github.com/suiramdev"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/suiramdev/bb-plugin-thread-namer.git",
+      "range": "^0.1.0"
+    }
+  }
+}


### PR DESCRIPTION
## What the plugin does

Thread Namer names bb threads with an agent, so the sidebar reads like a list of what you were doing instead of a list of first lines.

- **Automatic.** When a thread's first turn finishes, the plugin reads the opening of the conversation and writes a short title onto the thread. A title you typed yourself is never overwritten.
- **On demand.** A button in the thread header re-generates the name of the current thread; `bb thread-namer rename [<threadId>]` does the same from a terminal or an agent.
- **Your model.** By default the naming turn runs on the same model and harness as the thread it is naming. Settings → Plugins → Thread Namer lets you pin one model instead, from a searchable catalogue of every model your signed-in agents report.

Automatic naming skips hidden threads, child (subagent/background) threads, archived and deleted threads, and threads you named by hand.

## Source release

- Repository: https://github.com/suiramdev/bb-plugin-thread-namer (public, plugin at repository root)
- Tag: `v0.1.0` → commit `023d1229db020330a940e4bff060e23bd4b278d8`
- Entry source: git with semver `range: "^0.1.0"` (repository-wide `vX.Y.Z` tags, no `tagPrefix`, no `subdir`)

## Plugin checks

- `npm run typecheck` (`tsc --noEmit`) — passed
- `npm test` (vitest) — 53 tests across 4 files passed, on Node 22 per `.nvmrc`
- `bb plugin build` — passed, emits `dist/server.js` and `dist/app.js` + `dist/app.css`
- Working tree clean at the tagged commit

## Marketplace checks

- `npm ci --ignore-scripts` — 0 vulnerabilities
- `npm run build` — built `dist/marketplace.json` with 45 entries
- `npm run check` (`--liveness`) — passed; the git source and `^0.1.0` range resolve
- Only `entries/thread-namer.json` is added; no icon file (uses the host icon `AiContentGenerator01`, matching the plugin's own `bb.branding.icon`)

## Permissions, external services, security

- No external services and no network calls of its own. Naming runs entirely through bb's own agent APIs, on the agents you are already signed in to.
- The plugin never types into the thread it is naming. It spawns a hidden, throwaway thread that reuses the named thread's environment (so no worktree is created), runs one prompt on the least privileged permission mode the agent supports — naming needs no tools — then stops and deletes that worker on every path, including failures.
- The prompt sent is a truncated outline of the thread's first few turns, so thread content reaches the configured naming model and no one else.
- No credentials, tokens, or telemetry are read or stored. Settings are ordinary plugin config.
