### PR TITLE
Add project-instructions

### DIFF
--- a/entries/project-instructions.json
+++ b/entries/project-instructions.json
@@ -1,0 +1,24 @@
+{
+  "id": "project-instructions",
+  "displayName": "Project Instructions",
+  "description": "Gives each bb project its own standing instructions and adds them to the system prompt of every thread in that project, without writing anything into the repository.",
+  "icon": "FileText",
+  "tags": [
+    "instructions",
+    "agents",
+    "projects",
+    "prompt",
+    "monorepo",
+    "settings"
+  ],
+  "author": {
+    "name": "Roger Serra",
+    "github": "Hazihell"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/Hazihell/bb-plugin-project-instructions.git",
+      "range": "^0.1.0"
+    }
+  }
+}


### PR DESCRIPTION
## Project Instructions

Gives each bb project its own standing instructions and adds them to the system prompt of every thread in that project.

bb's built-in custom instructions are global: one block of text for every project. This makes them per project.

It exists for cases where a committed `AGENTS.md` is not available: a monorepo where only one subdirectory is yours, a repository you do not own, or a rule that is yours rather than your team's. Nothing is written to the working tree.

### Surfaces

- A settings section: project picker, editor, explicit save. Unsaved text survives switching projects.
- A CLI command: `bb project-instructions get|set|clear|list`. `--project` defaults to the calling thread's project, so an agent can read its own instructions with no arguments.

Both write through one code path.

### Notes for review

- Storage is the plugin's own key-value storage, keyed by project id. Injection is an exact lookup by project id, so one project's text cannot reach another's threads.
- `contributeInstructions` is synchronous on the thread-start path while storage is async, so rows are mirrored into a `Map` at load and every write updates storage and mirror together, one write at a time.
- bb truncates a contribution over 4096 characters silently, so writes over the limit are refused at the RPC, the CLI, and the editor, with a live count in the UI.
- The README states plainly that side chats never receive plugin instructions.

### Verification

- `npx tsc --noEmit` and `bb plugin build` pass.
- Installed from the published tag and exercised: `bb plugin install git:https://github.com/Hazihell/bb-plugin-project-instructions.git@^0.1.0` resolves `v0.1.0` (`1fdc01b`), builds from source, and runs.
- `npm run build` and `npm run check` pass in this repository with the entry added.

Source: https://github.com/Hazihell/bb-plugin-project-instructions (MIT)