### PR TITLE
Track floating-terminal v0.4.0

### DIFF
--- a/entries/floating-terminal.json
+++ b/entries/floating-terminal.json
@@ -21,7 +21,7 @@
   "source": {
     "git": {
       "url": "https://github.com/vburojevic/bb-plugin-floating-terminal.git",
-      "range": "^0.2.0"
+      "range": "^0.3.0"
     }
   }
 }

--- a/entries/floating-terminal.json
+++ b/entries/floating-terminal.json
@@ -21,7 +21,7 @@
   "source": {
     "git": {
       "url": "https://github.com/vburojevic/bb-plugin-floating-terminal.git",
-      "range": "^0.3.0"
+      "range": "^0.4.0"
     }
   }
 }


### PR DESCRIPTION
Bumps the `floating-terminal` range from `^0.2.0` to `^0.3.0`.

#56 was merged while `^0.2.0` was still in the entry, so the listing currently
resolves to v0.2.0 and cannot pick up v0.3.0 — a `^` range on a `0.x` version
allows patch releases only.

## What v0.3.0 adds

Below bb's compact-viewport breakpoint the window becomes a sheet: it fills the
viewport minus one even inset, measured from the safe area, over a blurred
backdrop, and drag and resize are not installed. It also fixes two layout bugs
in the directory picker that showed up on any viewport once a user has enough
projects — the list grew past its pane instead of scrolling, and the `+`
dropdown was uncapped.

## Checks

- 43 tests, `npm run typecheck`, `bb plugin build` — all clean
- Fresh `git clone --branch v0.3.0` + `npm install --omit=dev` + `bb plugin build`
- Verified in a real bb at both a phone viewport (sheet, blurred backdrop, even
  10px insets, no resize handles) and a desktop viewport (unchanged: window
  layout, 8 resize edges, drag still works, no backdrop)
- `npm run build` and `npm run check` here

Tag `v0.3.0` → commit `a4773bf`. No new permissions, services, or network access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
