### PR TITLE
Add plugin entry: disk-usage

### DIFF
--- a/entries/disk-usage.json
+++ b/entries/disk-usage.json
@@ -1,0 +1,22 @@
+{
+  "id": "disk-usage",
+  "displayName": "Disk Usage",
+  "description": "Shows what's taking up disk space on the bb server host, ncdu-style, with drill-down by directory and a bb disk-usage CLI.",
+  "icon": {
+    "url": "./icons/disk-usage-fff016e3.svg"
+  },
+  "tags": ["disk-usage", "storage", "ncdu", "server", "interface"],
+  "author": {
+    "name": "Nicolas Charpentier",
+    "github": "charpeni",
+    "url": "https://github.com/charpeni"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/charpeni/bb-plugins.git",
+      "subdir": "plugins/disk-usage",
+      "range": "^0.1.0",
+      "tagPrefix": "disk-usage/"
+    }
+  }
+}

--- a/icons/disk-usage-fff016e3.svg
+++ b/icons/disk-usage-fff016e3.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <line x1="22" y1="12" x2="2" y2="12" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <line x1="6" y1="16" x2="6.01" y2="16" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <line x1="10" y1="16" x2="10.01" y2="16" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## What it does

Disk Usage shows what's taking up disk space on the bb server host, `ncdu`-style: a sidebar panel scans a directory (the server home by default), lists its children largest-first with share bars, and drills down by click until you find the culprit, streaming live progress while a scan runs. Results are cached per path in memory so drilling back up is instant, with the snapshot's age shown and a Rescan button to force a fresh walk. The same scan is available to agents and scripts through a `bb disk-usage` CLI with `--top`, `--json`, and `--refresh` flags. Sizes are allocated disk blocks rather than apparent size, symlinks are never followed, hardlinks count once, unreadable entries are skipped rather than fatal, and a scan caps at 500,000 entries with the result flagged as truncated past that.

## Source

The plugin lives at `plugins/disk-usage` in `https://github.com/charpeni/bb-plugins.git` (public, MIT), which releases plugins independently with prefixed tags. The entry uses range `^0.1.0` with `tagPrefix: "disk-usage/"`, resolving to tag `disk-usage/v0.1.0` at commit `3bf316f`. The entry id `disk-usage` derives from the package name `bb-plugin-disk-usage` and matches the filename and manifest.

## Plugin checks

CI at the tagged commit passed all checks: build, test, typecheck, lint, format, validate, and npm-install-check. The manifest declares engines `bb >=0.38` and `bbPluginSdk >=0.4.6`; the entry omits an `engines` field because the marketplace schema doesn't define one, so BB's install pipeline enforces compatibility from the manifest.

## Marketplace checks

`npm ci --ignore-scripts`, `npm run build`, and `npm run check` all pass locally (liveness resolves the `disk-usage/v0.1.0` tag). The diff adds only `entries/disk-usage.json` and `icons/disk-usage-fff016e3.svg`, the plugin's own hard-drive artwork copied from the tagged commit and named with its content hash. `author.github` is `charpeni`, the account opening this PR.

## Permissions and security

The plugin reads directory metadata on the machine hosting the bb server — entry names and sizes only, never file contents — and keeps scan results in memory. It makes no network requests, needs no credentials, and sends no telemetry. Scans start only when the panel is opened or the CLI is invoked.
