### PR TITLE
Add plugin entry: command-center

### DIFF
--- a/entries/command-center.json
+++ b/entries/command-center.json
@@ -1,0 +1,17 @@
+{
+  "id": "command-center",
+  "displayName": "Command Center",
+  "description": "Boards every dispatched request and open question as a card, lets you answer or comment on an agent's work straight from the board, and sends macOS notifications when a card's status changes.",
+  "icon": "Mail",
+  "tags": ["kanban", "board", "tasks", "notifications", "voice", "productivity"],
+  "author": {
+    "name": "Dilip Venkatesh",
+    "github": "dilipgv"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/dilipgv/bb-plugin-command-center.git",
+      "range": "^0.4.0"
+    }
+  }
+}

--- a/entries/command-center.json
+++ b/entries/command-center.json
@@ -1,7 +1,7 @@
 {
   "id": "command-center",
   "displayName": "Command Center",
-  "description": "Boards every dispatched request and open question as a card, lets you answer or comment on an agent's work straight from the board, and sends macOS notifications when a card's status changes.",
+  "description": "Boards every dispatched request and open question as a card, lets you reply or comment on an agent's work straight from the board, and sends macOS notifications when a card's status changes. Includes Chief: one global Chief, a project chief per project, and task architects, for routing dispatched work through an org instead of a flat worker thread. Requires the Tasks plugin — the board offers a one-click install if it isn't already there, but never installs it silently — and, for voice input, microphone access. If you also run the `notify` plugin, expect two macOS banners for overlapping events — this one fires on board-card status, `notify` on thread lifecycle.",
   "icon": "Mail",
   "tags": ["kanban", "board", "tasks", "notifications", "voice", "productivity"],
   "author": {
@@ -11,7 +11,7 @@
   "source": {
     "git": {
       "url": "https://github.com/dilipgv/bb-plugin-command-center.git",
-      "range": "^0.7.0"
+      "range": "^0.7.1"
     }
   }
 }

--- a/entries/command-center.json
+++ b/entries/command-center.json
@@ -11,7 +11,7 @@
   "source": {
     "git": {
       "url": "https://github.com/dilipgv/bb-plugin-command-center.git",
-      "range": "^0.4.0"
+      "range": "^0.7.0"
     }
   }
 }


### PR DESCRIPTION
## What the plugin does

Command Center is the Captain's single surface for everything in flight: a Queue → In progress → In review → Done board, plus a derived Needs you lane for open questions and review requests agents raise (`bb inbox ask` / `bb inbox review`). Answers deliver back into the asking thread. Voice input, per-request harness/model selection, a full reading view per card, archiving that cascades to worker threads and worktrees, and macOS lane-change notifications.

## Screenshots

Board (Queue/In progress/In review/Needs you/Done):

![Board](https://raw.githubusercontent.com/dilipgv/bb-plugin-command-center/77b2409/docs/screenshots/board.png)

A card's reading view:

![Reading view](https://raw.githubusercontent.com/dilipgv/bb-plugin-command-center/77b2409/docs/screenshots/reading-view.png)

An open question, answerable straight from the board:

![Question card](https://raw.githubusercontent.com/dilipgv/bb-plugin-command-center/f5f8e58/docs/screenshots/question-card.png)

## Source release

- Git: `https://github.com/dilipgv/bb-plugin-command-center.git`
- Range: `^0.4.0`, resolved against tag `v0.4.0` (root of the repo, no subdir/tagPrefix)

## Checks that succeeded

- `bb plugin build` (server + app bundle)
- `npx tsc --noEmit`
- `npm run build` in this marketplace checkout (45 entries, including this one)
- `npm run check` (schema validation + live resolution of the `^0.4.0` git range against the pushed tag)

## Permissions / external services

- Uses `osascript` for macOS notifications (no-op elsewhere).
- Optional voice transcription via BB's own configured transcription model.
- No third-party network calls; all board data comes from this plugin's own storage plus BB's Tasks plugin.
- Dispatches to a separate companion plugin (`chief-nav`, not yet submitted) for full "send to Chief" routing; works standalone without it, with dispatch surfacing a clear error if that plugin is absent.
