### PR TITLE
Add plugin entry: agent-plugins

### DIFF
--- a/entries/agent-plugins.json
+++ b/entries/agent-plugins.json
@@ -1,7 +1,7 @@
 {
   "id": "agent-plugins",
   "displayName": "Agent Plugins",
-  "description": "Installs Agent Plugins once in BB and routes their skills and approved MCP tools to every provider, with per-resource enable controls.",
+  "description": "Installs plugins that follow the Agent Plugins spec in BB, making their skills and approved MCP tools available to Codex and other BB providers; it is not a Claude marketplace integration.",
   "icon": "Puzzle",
   "tags": ["agent-tools", "skills", "mcp", "integrations", "providers", "developer-tools"],
   "author": {

--- a/entries/agent-plugins.json
+++ b/entries/agent-plugins.json
@@ -1,0 +1,20 @@
+{
+  "id": "agent-plugins",
+  "displayName": "Agent Plugins",
+  "description": "Installs Agent Plugins once in BB and routes their skills and approved MCP tools to every provider, with per-resource enable controls.",
+  "icon": "Puzzle",
+  "tags": ["agent-tools", "skills", "mcp", "integrations", "providers", "developer-tools"],
+  "author": {
+    "name": "Patrick Lee",
+    "github": "patleeman",
+    "url": "https://github.com/patleeman"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/patleeman/bb-plugins.git",
+      "subdir": "packages/bb-plugin-agent-plugins",
+      "range": "^0.1.0",
+      "tagPrefix": "agent-plugins/"
+    }
+  }
+}

--- a/entries/agent-plugins.json
+++ b/entries/agent-plugins.json
@@ -13,7 +13,7 @@
     "git": {
       "url": "https://github.com/patleeman/bb-plugins.git",
       "subdir": "packages/bb-plugin-agent-plugins",
-      "range": "^0.1.0",
+      "range": "^0.3.0",
       "tagPrefix": "agent-plugins/"
     }
   }


### PR DESCRIPTION
## What the plugin does

Agent Plugins installs packages that follow the Agent Plugins spec once in BB, materializes their skills for agent sessions, and routes approved MCP tools to Codex and other BB providers. The release adds independent enable/disable controls for each discovered skill and MCP server. It is not a Claude marketplace integration.

## Source release

- Repository: https://github.com/patleeman/bb-plugins.git
- Plugin subdirectory: `packages/bb-plugin-agent-plugins`
- Release: `agent-plugins/v0.1.0`
- Selected source range: `^0.1.0`

## Plugin checks

- 33 focused tests passed
- TypeScript typecheck passed
- BB plugin build passed
- BB SDK compatibility check passed
- `npm pack --dry-run` contains the runtime bundles, metadata, manifest, and schemas
- Live BB reload and per-resource toggle checks passed

## Marketplace checks

- `npm ci --ignore-scripts` passed
- `npm run build` passed
- `npm run check` passed, including public Git release liveness
- Entry ID, source subdirectory, release tag prefix, and host icon validated against the current marketplace schema

## Permissions and security

The plugin reads plugin sources and stores installed plugin data under BB-managed storage. Skills are materialized only when enabled. MCP servers remain approval-gated; enabled stdio servers run user-selected plugin commands, and supported local HTTP configuration is validated before use. Sensitive MCP environment and header values are redacted from the settings snapshot.
