### PR TITLE
Add plugin entry: tokenmaxx

### DIFF
--- a/entries/tokenmaxx.json
+++ b/entries/tokenmaxx.json
@@ -1,0 +1,27 @@
+{
+  "id": "tokenmaxx",
+  "displayName": "tokenmaxx",
+  "description": "Shows every Codex and Claude Code account tokenmaxx manages, with live rate-limit windows, token analytics, account switching, auto-rotation policy, sign-in, and routing control.",
+  "icon": {
+    "url": "./icons/tokenmaxx-05b77465.svg"
+  },
+  "tags": [
+    "tokenmaxx",
+    "providers",
+    "rate-limits",
+    "analytics",
+    "accounts",
+    "developer-tools"
+  ],
+  "author": {
+    "name": "Pedro Filho",
+    "github": "pedroapfilho",
+    "url": "https://github.com/pedroapfilho"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/pedroapfilho/bb-plugin-tokenmaxx.git",
+      "range": "^0.1.1"
+    }
+  }
+}

--- a/icons/tokenmaxx-05b77465.svg
+++ b/icons/tokenmaxx-05b77465.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" color="#000" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3.54 18.08a9 9 0 1 1 16.92 0"/>
+  <path d="M12 15.5 16.2 9.4"/>
+</svg>


### PR DESCRIPTION
## What the plugin does

Adds a nav panel for [tokenmaxx](https://github.com/RubricLab/tokenmaxx), the local proxy that keeps
several Codex and Claude Code subscription accounts signed in and picks which one serves each
request.

- **Accounts** one card per provider, accounts ordered by headroom, a bar per rate-limit window with
  reset countdowns, make-active, sign out, Codex reset credits, hide a window, and auto-rotation with
  threshold, hold, and hysteresis.
- **Analytics** token throughput and cost at API list prices from 1 hour to 31 days, with
  per-provider and per-model breakdowns.
- **Setup** daemon start and stop, proxy address, OAuth or API-key sign-in, routing install and
  uninstall for codex, claude, and pi, and the full `tokenmaxx doctor` report.

The sidebar row carries the fullest window across the active accounts, so pressure is readable
without opening the panel.

## Source release

`git` source, `https://github.com/pedroapfilho/bb-plugin-tokenmaxx.git`, range `^0.1.1`, tagged
`v0.1.1` (annotated, never moved). v0.1.0 is also tagged.

## Plugin checks

- `npx tsc --noEmit` clean for both entries.
- `bb plugin build` emits `dist/server.js`, `dist/app.js`, and `dist/app.css`.
- Clean clone with `npm install --omit=dev` under `NODE_ENV=production` builds both artifacts, so the
  git install path works without dev dependencies.
- Installed and exercised against a live tokenmaxx 0.0.65 daemon: state, usage refresh, doctor,
  policy updates, hidden windows, reset-credit read, account switch, and the login terminal stream.

## Marketplace checks

- `npm ci --ignore-scripts`, `npm run build`, and `npm run check` all pass (63 entries).
- Icon vendored at `icons/tokenmaxx-05b77465.svg` (original artwork, 2 paths, no scripts or remote
  references), filename hashed from its content.
- `author.github` is the account opening this pull request.

## Security and permissions

- Talks to tokenmaxx's local unix socket at `~/.tokenmaxx/runtime/manager.sock` for reads and
  account actions, and shells out to the `tokenmaxx` binary only for `doctor`, routing install and
  uninstall, daemon control, and login.
- Login runs `tokenmaxx login <provider>` in a bb terminal because the provider CLIs need a pty. The
  plugin never reads or stores credentials: tokenmaxx puts them in the macOS Keychain, and an API key
  is typed into that terminal rather than passed on a command line.
- No network calls of its own, no telemetry, no data leaves the machine.
- macOS only, since tokenmaxx is macOS only.
