### PR TITLE
Add plugin entry: monaco

### DIFF
--- a/entries/monaco.json
+++ b/entries/monaco.json
@@ -1,0 +1,25 @@
+{
+  "id": "monaco",
+  "displayName": "Monaco",
+  "description": "Opens files in BB's Monaco editor instead of the read-only preview, with save, find, syntax highlighting for ~86 file types, and a filterable file tree.",
+  "icon": "Code",
+  "tags": [
+    "editor",
+    "monaco",
+    "files",
+    "file-tree",
+    "interface",
+    "developer-tools"
+  ],
+  "author": {
+    "name": "Andrew Chan",
+    "github": "andrewkchan",
+    "url": "https://github.com/andrewkchan"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/andrewkchan/bb-plugin-monaco.git",
+      "range": "^0.1.0"
+    }
+  }
+}


### PR DESCRIPTION
## Human comments

This plugin provides monaco as a file editor in BB, because often I want to edit/view files right in the app, it's annoying to switch screens to an IDE. Features:
- Intercepting all file open actions in BB
- View and edit files
- Navigate the file tree
- Find and replace in file
- Basic syntax highlighting

Not yet supported:
- No LSP support
- No deleting/renaming/creating new files yet

Untested:
- Support for remote workspaces (actually, I am not sure how well BB supports these yet)

Checkout https://github.com/andrewkchan/bb-plugin-monaco for the plugin page.

<img width="2530" height="1642" alt="image" src="https://github.com/user-attachments/assets/416c401c-4371-44a3-883a-e7e0fb4bffd7" />

-----

## What the plugin does

Monaco replaces BB's read-only file preview with the VS Code editor. It takes over
everywhere BB opens a file — links clicked in chat, the secondary panel's file
search, and `bb thread open`.

- Edit and save with ⌘S. If the file changed on disk since it was opened (often
  because the agent edited it), the save stops and offers Reload or Overwrite
  rather than clobbering the change.
- Find in file with ⌘F, plus Monaco's usual editing: multiple cursors, block
  selection, bracket matching, code folding.
- Syntax highlighting for ~86 common file types.
- A file tree in the file bar: browse the project, filter by path, expand and
  collapse directories, jump to another file. Right-click a row to copy its
  absolute path, relative path, or filename.
- Follows the active BB theme, including light/dark switches and custom palettes.

## Source release

`git` source on <https://github.com/andrewkchan/bb-plugin-monaco> (public), range
`^0.1.0`, resolved over repository-wide `vX.Y.Z` tags. The first release tag
`v0.1.0` is an annotated tag at commit `f165b11`. No `subdir` or `tagPrefix`: the
plugin is at the repository root and is the only plugin in the repo.

## Plugin checks

- `npx tsc --noEmit` — clean.
- `bb plugin build` — clean; emits `dist/server.js`, `dist/app.js`, `dist/app.css`
  and their meta files.
- Working tree clean at the tagged commit.

## Marketplace checks

- `npm ci --ignore-scripts`
- `npm run build` — composes `dist/marketplace.json` with 63 entries.
- `npm run check` — liveness pass; the git source and `^0.1.0` range resolve.

## Notes for reviewers

- **Compatibility.** The plugin manifest declares `engines.bb >= 0.38` and
  `engines.bbPluginSdk >= 0.4.6`. It needs a BB with a working `fileOpener` slot
  (get-bb/bb#2026); on an older host the file opener simply will not register.
- **Icon.** Uses the host icon name `Code`, matching the plugin manifest's
  `bb.branding.icon`. No file is vendored into `icons/`.
- **Permissions and external services.** None. No network calls and no telemetry;
  Monaco is bundled from the npm dependency rather than loaded from a CDN. The
  plugin server reads and writes files in the workspace and on the host, which is
  the feature itself — saving is always user-initiated.
