### PR TITLE
Add plugin entry: diffui-bb

### DIFF
--- a/entries/diffui-bb.json
+++ b/entries/diffui-bb.json
@@ -1,0 +1,25 @@
+{
+  "id": "diffui-bb",
+  "displayName": "Diffui",
+  "description": "Runs Diffui's design canvas inside bb, lists the canvases that belong to bb alongside your threads, and turns a right-click on any design into a new bb thread with that design attached.",
+  "icon": "Palette",
+  "tags": [
+    "design",
+    "canvas",
+    "diffui",
+    "agent-tools",
+    "mockups",
+    "prototyping"
+  ],
+  "author": {
+    "name": "Jacob Miller",
+    "github": "jjcm",
+    "url": "https://github.com/jjcm"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/jjcm/diffui-bb.git",
+      "range": "^0.1.0"
+    }
+  }
+}


### PR DESCRIPTION
## What it does

Diffui brings [Diffui](https://diffui.ai)'s design canvas into bb, so design and implementation live in the same window.

- **Diffui's real canvas, in bb.** The "Diffui" sidebar page mounts Diffui's own `<diffui-canvas-workspace>` element — no iframe, no re-implementation. Pan/zoom, option stacks, noodles, comments, prompt editing, generation, undo and collab are Diffui's code running in bb. The plugin redefines Diffui's `--canvas-*` tokens in terms of bb's host tokens, so the canvas follows bb's light and dark themes.
- **bb-owned files as threads.** The thread list is wrapped to list only the canvases that belong to bb — created here or explicitly opened from the browse grid. Membership lives in the plugin's own SQLite table via `bb.storage.database()`; a Diffui account's other files stay in Diffui.
- **Build with bb.** Right-click a design on a canvas and the plugin fetches the design bytes, uploads them through `bb.sdk.projects.attachments.upload`, and spawns a thread with a visible brief, `localImage` refs, and an agent-only structured brief.
- **Agent tools.** `diffui_create_canvas`, `diffui_generate_options`, `diffui_get_canvas`, `diffui_create_build_link`.

![Build with bb from a Diffui canvas inside bb](https://raw.githubusercontent.com/jjcm/diffui-bb/121e53cc17e13767b0a912f73d5b24d2541218f5/docs/shots/shot_bb_window_canvas_build_with_bb.png)

## Source release

Git semver range `^0.1.0` over `https://github.com/jjcm/diffui-bb.git`, repository root (no `subdir`, no `tagPrefix`). Tag `v0.1.0` is annotated and points at `b5a879c51b5ec94c3c93f8a190a5e520210a8fe2`.

The entry uses the BB host icon name `Palette`, matching the plugin manifest's `bb.branding.icon`. The repository ships no logo artwork, so nothing is vendored into `icons/`.

## Plugin checks

Run against a clean `git worktree` checkout of the tagged commit, with `npm ci`:

- `npm run typecheck` (`tsc --noEmit`) — clean
- `npm test` (vitest) — 7 files, 87 tests passing
- `bb plugin build` — emits `dist/server.js`, `dist/app.js`, `dist/app.css`

## Marketplace checks

- `npm ci --ignore-scripts`
- `npm run build` — 64 entries
- `npm run check` (`--liveness`) — 64 entries, source resolves

## Notes for reviewers

- **Network.** The plugin talks to a Diffui server over its public API only — JSON, file uploads, and a websocket. No Diffui schema changes and no private endpoints.
- **Credentials.** Diffui auth is handled by the plugin's own settings; no tokens are read from or written to bb's config outside plugin storage.
- **Storage.** One SQLite table in the plugin's own database, tracking which Diffui files were opened into bb.
- **Manifest engines.** `bb >=0.38`, `bbPluginSdk >=0.4.8`. Developed and verified against bb 0.39.0.
