### PR TITLE
Add Copy Session ID plugin

### DIFF
--- a/entries/copy-session-id.json
+++ b/entries/copy-session-id.json
@@ -1,0 +1,20 @@
+{
+  "id": "copy-session-id",
+  "displayName": "Copy Session ID",
+  "description": "Copy a thread's session ID from its left-sidebar context menu.",
+  "icon": "Copy",
+  "tags": ["clipboard", "threads", "sidebar"],
+  "author": {
+    "name": "Patrick Lee",
+    "github": "patleeman",
+    "url": "https://github.com/patleeman"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/patleeman/bb-plugins.git",
+      "subdir": "packages/bb-plugin-copy-session-id",
+      "range": "^0.1.0",
+      "tagPrefix": "copy-session-id/"
+    }
+  }
+}


### PR DESCRIPTION
Adds the copy-session-id plugin to the BB Community marketplace. Source: https://github.com/patleeman/bb-plugins/tree/copy-session-id/v0.1.0. The plugin adds a native-style Copy session ID action to left-sidebar thread context menus. Validation: npm run build and npm run check.