### PR TITLE
Add plugin entry: server-status

### DIFF
--- a/entries/server-status.json
+++ b/entries/server-status.json
@@ -1,0 +1,30 @@
+{
+  "id": "server-status",
+  "displayName": "Server Status",
+  "description": "Tracks host RAM usage as a ring around a sidebar footer button \u2014 amber from 80%, red above 90% \u2014 and opens a panel with CPU, memory, swap, disk, load average, uptime, and OS and kernel version.",
+  "icon": {
+    "url": "./icons/server-status-0fe86d02.svg"
+  },
+  "tags": [
+    "server",
+    "monitoring",
+    "memory",
+    "disk",
+    "uptime",
+    "sidebar",
+    "interface"
+  ],
+  "author": {
+    "name": "Foma",
+    "github": "xMinor-1",
+    "url": "https://github.com/xMinor-1"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/xMinor-1/bb-plugins.git",
+      "subdir": "plugins/server-status",
+      "range": "^0.1.0",
+      "tagPrefix": "server-status/"
+    }
+  }
+}

--- a/icons/server-status-0fe86d02.svg
+++ b/icons/server-status-0fe86d02.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-label="Server Status">
+  <path d="M2.5 13h3.4l2.3-6.6 3.4 12.2 2.6-8.4 1.7 2.8h5.6"
+        fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## What the plugin does

Adds a server health indicator to the bb sidebar footer. A ring around the
button tracks RAM usage on the machine running bb — muted below 80%, amber from
80%, red above 90%, refreshed every five seconds. Clicking the button opens a
panel with the CPU and its core count, memory, swap (with a plain-language
warning once memory is being pushed to disk), disk usage for a configurable
mount point, load average over 1/5/15 minutes, uptime with the date of the last
boot, and the OS and kernel version.

Metrics are read straight from the kernel — `/proc/stat`, `/proc/meminfo`,
`statfs`, `/etc/os-release` — with no dependencies and no shelling out. One
background service polls every five seconds for the whole server and serves the
snapshot over a single `state` RPC method, so cost does not grow with the number
of open tabs.

## Source release

- `git`: `https://github.com/xMinor-1/bb-plugins.git`
- `subdir`: `plugins/server-status`
- `tagPrefix`: `server-status/`, `range`: `^0.1.0`
- Released tag: `server-status/v0.1.0` → commit `4bff05a145db24d3457cb541f37aa70e420f0c23`

## Plugin checks

- `npx tsc --noEmit` — clean
- `bb plugin build .` — builds `dist/server.js`, `dist/app.js`, `dist/app.css` and their meta
- Engines declared by the manifest: `bb >=0.39`, `bbPluginSdk >=0.4.8`

## Marketplace checks

- `npm ci --ignore-scripts`, `npm run build`, `npm run check` — all pass, 64 entries
- Icon vendored to `icons/server-status-0fe86d02.svg` (290 bytes, no scripts, no remote references)

## Permissions and security

Read-only, local, and host-only. The plugin reads `/proc/stat`, `/proc/meminfo`
and `/etc/os-release`, calls `statfs` on one mount point, and uses Node's `os`
module. It makes no network calls, writes nothing, and runs no external
commands. The only setting is `diskPath`, the mount point to report on.

The frontend adds its own `<svg>` inside the host footer button and its panel to
`document.body`; nodes it does not own are never moved or removed, and
everything it creates is torn down by its disposer.
