### PR TITLE
Add plugin entry: file-manager

### DIFF
--- a/entries/file-manager.json
+++ b/entries/file-manager.json
@@ -1,7 +1,7 @@
 {
   "id": "file-manager",
   "displayName": "File Manager",
-  "description": "Browse, upload, download, move, rename and extract files under your home folder from a full-page bb panel, with folders that expand in place and chunked resumable uploads for multi-gigabyte files.",
+  "description": "Browse, upload, download, move, rename and extract files under your home folder from a full-page bb panel: folders expand in place, a browser-style path bar jumps to any pasted path, the panel reopens where you left it, and multi-gigabyte uploads resume after a dropped connection.",
   "icon": "FolderOpen",
   "tags": [
     "files",
@@ -20,7 +20,7 @@
     "git": {
       "url": "https://github.com/xMinor-1/bb-plugins.git",
       "subdir": "plugins/file-manager",
-      "range": "^0.3.0",
+      "range": "^0.4.0",
       "tagPrefix": "file-manager/"
     }
   }

--- a/entries/file-manager.json
+++ b/entries/file-manager.json
@@ -1,0 +1,27 @@
+{
+  "id": "file-manager",
+  "displayName": "File Manager",
+  "description": "Browse, upload, download, move, rename and extract files under your home folder from a full-page bb panel, with folders that expand in place and chunked resumable uploads for multi-gigabyte files.",
+  "icon": "FolderOpen",
+  "tags": [
+    "files",
+    "file-manager",
+    "uploads",
+    "downloads",
+    "host-access",
+    "interface"
+  ],
+  "author": {
+    "name": "Foma",
+    "github": "xMinor-1",
+    "url": "https://github.com/xMinor-1"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/xMinor-1/bb-plugins.git",
+      "subdir": "plugins/file-manager",
+      "range": "^0.3.0",
+      "tagPrefix": "file-manager/"
+    }
+  }
+}


### PR DESCRIPTION
## What the plugin does

Adds a full-page file manager for the machine that runs the bb server, reachable
from a "File Manager" item in the sidebar. It covers the work that otherwise
needs a shell: a tree whose folders expand in place, drag-and-drop upload,
streamed download, move, copy, rename, delete, and archive extraction.

Uploads are chunked and resumable, so a dropped connection continues instead of
starting over — tested on a 5 GB file. Downloads are streamed rather than
buffered.

## Source release

- `git`: `https://github.com/xMinor-1/bb-plugins.git`
- `subdir`: `plugins/file-manager`
- `tagPrefix`: `file-manager/`, `range`: `^0.3.0`
- Released tag: `file-manager/v0.3.0` → commit `54eddc767af63a0183d0949c59ee59f83e2b3c61`

## Plugin checks

Run against the exact released commit in a clean worktree:

- `npx tsc --noEmit` — clean
- `bb plugin build .` — builds `dist/server.js`, `dist/app.js`, `dist/app.css` and their meta
- Engines declared by the manifest: `bb >=0.39`, `bbPluginSdk >=0.4.8`

## Marketplace checks

- `npm ci --ignore-scripts`, `npm run build`, `npm run check` — all pass, 64 entries
- Icon: the BB host icon name `FolderOpen`, the same one the plugin manifest declares

## Permissions and security

This plugin reads and writes files on the bb host, which is its purpose, so the
boundary matters:

- Every path is resolved with `realpath` **before** the root prefix test, so a
  symlink cannot be used to address anything outside the hard root — the home
  directory of the user running bb. A path that resolves outside is refused
  (`src/root.ts`, which is the only place in the plugin allowed to build a
  filesystem path from user input).
- Archive extraction treats an archive as attacker-controlled data. Entries are
  staged into a private `<dest>/.bb-extract-<hex>/out` directory the plugin
  owns, so a `../` escape (the classic zip-slip) still lands inside it; anything
  written beside `out` is swept away; every symlink in the result is re-checked
  against the hard root once it sits at its final path; only then is the tree
  committed to the destination.
- Extraction does shell out to `tar` / `unzip` / `7z`, via `spawn` with an
  argument list rather than a shell string, with `--no-same-owner
  --no-same-permissions`. The client cannot name a command or a destination —
  the format is detected by the plugin and the destination is derived from the
  validated path.
- All client operations go through the plugin's own authenticated RPC and HTTP
  routes.
- No network calls to anything outside the bb host.
