### PR TITLE
Add plugin entry: xcode

### DIFF
--- a/entries/xcode.json
+++ b/entries/xcode.json
@@ -1,0 +1,30 @@
+{
+  "id": "xcode",
+  "displayName": "Xcode",
+  "description": "Tracks every Xcode build and test on the machine with no per-project configuration \u2014 live progress, verdicts, errors with file:line, history and trends \u2014 and streams the simulators they run on into the panel with full touch input, a build-aware device picker, SwiftUI preview diffs, and gated agent tools.",
+  "icon": {
+    "url": "./icons/xcode-52038a9f.svg"
+  },
+  "tags": [
+    "xcode",
+    "ios",
+    "simulator",
+    "builds",
+    "tests",
+    "swiftui",
+    "previews",
+    "snapshots",
+    "agent-tools"
+  ],
+  "author": {
+    "name": "Vedran Burojevic",
+    "github": "vburojevic",
+    "url": "https://github.com/vburojevic"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/vburojevic/bb-plugin-xcode.git",
+      "range": "^0.2.0"
+    }
+  }
+}

--- a/icons/xcode-52038a9f.svg
+++ b/icons/xcode-52038a9f.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- The plugin's toolbox mark. BB renders plugin icons as CSS masks keyed
+       off alpha coverage, so the stroke is an opaque literal rather than
+       currentColor, which has no inherited context inside a mask source. -->
+  <path d="M9 7V5a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2"/>
+  <rect x="3" y="7" width="18" height="13" rx="2"/>
+  <path d="M3 13h6"/>
+  <path d="M15 13h6"/>
+  <path d="M9 11h6v4H9z"/>
+</svg>


### PR DESCRIPTION
## What the plugin does

Tracks every Xcode build and test on the machine with **zero per-project
configuration** — the tracker learns DerivedData roots from the builds
themselves — and shows live progress, verdicts, errors and failed tests with
`file:line`, per-project history and trends. The same panel streams any booted
iOS simulator over hardware H.264 with full touch input (tap, drag, flick,
long-press, trackpad pinch, ⌘V paste, keyboard), a device picker ranked by
what your builds actually target, and SwiftUI preview rendering with diffs
against the last run (Stills).

## Source

- `https://github.com/vburojevic/bb-plugin-xcode.git`, range `^0.2.0`
- Released tag: `v0.2.0` (annotated, on `main`), MIT licensed, public repo

## Plugin checks

- `npx tsc --noEmit` clean; `vitest run` — 55 files, 728 passed / 3 skipped
- `bb plugin build` produces `dist/server.js`, `dist/app.js`, `dist/app.css`

## Marketplace checks

- `npm run build` and `npm run check` (liveness) both pass — 64 entries
- Icon vendored at `icons/xcode-52038a9f.svg` (stroke glyph, alpha-mask safe)

## Security facts for reviewers

- The simulator capture host (`serve-sim`, pinned 0.1.45) binds loopback only
  behind a route allowlist; the plugin has **no** public viewer, exposure
  command, or shared-port declaration.
- Model-facing simulator tools and their CLI equivalents are **off by
  default** behind an `allowAgentCapture` setting, re-checked per call.
- Tracked builds execute only `/usr/bin/xcodebuild`, path-confined to the
  invoking thread's checkout, with an environment allowlist.
- Full model: [SECURITY.md](https://github.com/vburojevic/bb-plugin-xcode/blob/main/SECURITY.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
