### PR TITLE
Add plugin entry: ports

### DIFF
--- a/entries/ports.json
+++ b/entries/ports.json
@@ -1,0 +1,25 @@
+{
+  "id": "ports",
+  "displayName": "Ports",
+  "description": "Lists active TCP ports across connected BB hosts and lets users open, copy, or stop listening processes.",
+  "icon": {
+    "url": "./icons/ports-3bfa4d52.svg"
+  },
+  "tags": [
+    "ports",
+    "developer-tools",
+    "networking",
+    "process-management"
+  ],
+  "author": {
+    "name": "Rama Audra",
+    "github": "ramaaudra",
+    "url": "https://github.com/ramaaudra"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/ramaaudra/bb-plugin-ports.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/icons/ports-3bfa4d52.svg
+++ b/icons/ports-3bfa4d52.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M8 3v5M16 3v5" stroke="currentColor" stroke-linecap="round" stroke-width="1.8"/>
+  <path d="M6 8h12v2a6 6 0 0 1-12 0V8Z" stroke="currentColor" stroke-linejoin="round" stroke-width="1.8"/>
+  <path d="M12 16v5M9 21h6" stroke="currentColor" stroke-linecap="round" stroke-width="1.8"/>
+</svg>


### PR DESCRIPTION
## What the plugin does

Ports lists active TCP listeners across connected BB hosts, groups matching
processes by workspace, and keeps unmatched listeners under External ports.
Each row can open the service, copy its resolved URL, or stop the process after
confirmation.

## Source release

- Repository: https://github.com/ramaaudra/bb-plugin-ports
- Release tag: `v0.1.0`
- Marketplace source: Git semver range `^0.1.0`

## Plugin checks

- `npm run typecheck`
- `bb plugin build`
- `npm pack --dry-run --ignore-scripts`
- Live `listPorts` RPC check returned successfully with no scan errors.

## Marketplace checks

- `npm ci --ignore-scripts`
- `npm run build`
- `npm run check`
- `git diff --check`

## Permissions and security

The plugin uses BB host process inspection to read TCP listeners and process
working directories. The Kill action requires confirmation, rechecks PID and
port ownership, and sends `SIGTERM`; it does not force-kill processes. The
plugin does not use external services.
