### PR TITLE
Add plugin entry: usage-meter

### DIFF
--- a/entries/usage-meter.json
+++ b/entries/usage-meter.json
@@ -1,0 +1,30 @@
+{
+  "id": "usage-meter",
+  "displayName": "Usage Meter",
+  "description": "Shows Claude subscription limits as two rings around a sidebar footer button — the five-hour session and the week — and adds a Usage page that reads local Claude Code transcripts to explain where the limits went, broken down by project, model, thread, skill and subagent.",
+  "icon": {
+    "url": "./icons/usage-meter-93d96ace.svg"
+  },
+  "tags": [
+    "usage",
+    "limits",
+    "tokens",
+    "claude-code",
+    "analytics",
+    "sidebar",
+    "interface"
+  ],
+  "author": {
+    "name": "Foma",
+    "github": "xMinor-1",
+    "url": "https://github.com/xMinor-1"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/xMinor-1/bb-plugins.git",
+      "subdir": "plugins/usage-meter",
+      "range": "^0.2.0",
+      "tagPrefix": "usage-meter/"
+    }
+  }
+}

--- a/icons/usage-meter-93d96ace.svg
+++ b/icons/usage-meter-93d96ace.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round">
+  <path d="M5.94 18.5A7 7 0 1 1 18.06 18.5"/>
+  <path d="M12 15 14.6 10.7"/>
+  <circle cx="12" cy="15" r="1.3" fill="#000" stroke="none"/>
+</svg>


### PR DESCRIPTION
## What the plugin does

Two rings around a sidebar footer button track Claude subscription limits: the
outer one the five-hour session, the inner one the week. Each ring colours by
its own value — muted below 60%, amber from 60%, red above 85%. A per-model
limit gets no ring of its own (a third ring stops being readable on a 32×32
button) but lights a dot on the button once it crosses the amber threshold.
Hovering or clicking opens a popup with every limit window, reset times in local
time, and the plan and account email. A failed poll does not blank the rings:
the previous figures stay, and a popup row states their age and the cause.

Behind the rings, a Usage page explains where the limits went. It reads the
local Claude Code transcripts and reports the same weighted-cost summary the
Claude Code VS Code extension gives — long context, subagent-heavy sessions,
sessions running in parallel, eight-hour sessions, cache misses — over the last
24 hours or 7 days, plus breakdowns the extension has no counterpart for:
workflow runs, background runs and their agents, skills with how often they ran,
and tokens by project, model and bb thread.

## Source release

- `git`: `https://github.com/xMinor-1/bb-plugins.git`
- `subdir`: `plugins/usage-meter`
- `tagPrefix`: `usage-meter/`, `range`: `^0.2.0`
- Released tag: `usage-meter/v0.2.0` → commit `5a1cb4fda6c11e3c869a543b4f4b0075b92b1f2c`

## Plugin checks

- `npx tsc --noEmit` — clean
- `bb plugin build .` — builds `dist/server.js`, `dist/app.js`, `dist/app.css` and their meta
- Installed and running against bb 0.39.0: plugin `running`, its background service `running`, no `degraded` state, browser console clean
- Engines declared by the manifest: `bb >=0.39`, `bbPluginSdk >=0.4.8`

## Marketplace checks

- `npm ci --ignore-scripts`, `npm run build`, `npm run check` — all pass
- Icon vendored to `icons/usage-meter-93d96ace.svg` (296 bytes, no scripts, no remote references)

## Data access and privacy — please read

This is the part reviewers should weigh, because the Usage page reads personal
data:

- **What it reads.** `~/.claude/projects/**/*.jsonl` — the local Claude Code
  transcripts — and the bb database, opened read-only (`mode=ro`) to attribute
  usage to bb threads. Limit percentages themselves come from
  `bb.sdk.system.usageLimits()`.
- **What it keeps.** Counters and names: token counts, timestamps, model ids,
  project and thread names, skill and subagent names, and slash-command names.
  Message prose is parsed in memory to classify a record and is not retained,
  aggregated or displayed — from message content the scanner takes length and
  block counts only.
- **Where it goes.** Nowhere. There are no outbound network calls. Aggregates
  live in a cache beside the plugin's own data and are served to the plugin's
  own panel over its authenticated RPC.
- **Cost of a scan.** A first cold pass over roughly 2 GB of transcripts takes
  seconds; later passes read only the tails of changed files.

Anyone installing this should know it reads their local Claude Code history, so
the entry description says so directly rather than burying it.

## Other notes

The footer ring shares its geometry with the author's `server-status` plugin
(PR #89) on purpose: the two buttons sit side by side and are meant to read as
one system. Neither plugin moves or removes nodes it does not own; each adds its
own `<svg>` inside the host footer button and tears everything down through its
disposer.
