### PR TITLE
Add plugin entry: provider-authentication

### DIFF
--- a/entries/provider-authentication.json
+++ b/entries/provider-authentication.json
@@ -1,0 +1,24 @@
+{
+  "id": "provider-authentication",
+  "displayName": "Provider Authentication",
+  "description": "Authenticates and reauthenticates Claude Code on connected bb machines from BB settings.",
+  "icon": "Lock",
+  "tags": [
+    "providers",
+    "authentication",
+    "oauth",
+    "claude-code",
+    "settings"
+  ],
+  "author": {
+    "name": "wjin17",
+    "github": "wjin17",
+    "url": "https://github.com/wjin17"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/wjin17/bb-plugin-provider-authentication.git",
+      "range": "^0.1.0"
+    }
+  }
+}


### PR DESCRIPTION
## What it does

Provider Authentication adds a Providers section to BB settings for authenticating or reauthenticating Claude Code on a connected machine. It starts Claude Code's standard subscription OAuth flow, opens the consent screen, and submits the authorization code pasted by the user.

## Release

- Source: `https://github.com/wjin17/bb-plugin-provider-authentication.git`
- Version: `v0.1.0`
- Marketplace range: `^0.1.0`

## Verification

- `npm run typecheck`
- `npm test` — 16 tests passed
- `npm run build`
- `npm pack --dry-run --ignore-scripts`
- Marketplace `npm run build`
- Marketplace `npm run check`

## Security and external services

The plugin executes `claude auth status` and `claude auth login --claudeai` through BB's host worker on the selected machine. The pasted authorization code is written directly to the retained Claude process and is not persisted, logged, or published in realtime events. Authentication credentials remain managed by Claude Code. The OAuth consent screen is hosted by Claude.
