### PR TITLE
Add plugin entry: bots

### DIFF
--- a/entries/bots.json
+++ b/entries/bots.json
@@ -1,0 +1,28 @@
+{
+  "id": "bots",
+  "displayName": "Bots",
+  "description": "Adds a Bots panel to the BB sidebar where you create named bots with their own instructions, provider, model, reasoning level and optional project, then chat with them; each bot's instructions are bound per-thread, so a persona applies only inside that bot's own chats.",
+  "icon": {
+    "url": "./icons/bots-48f12e36.svg"
+  },
+  "tags": [
+    "bots",
+    "personas",
+    "instructions",
+    "chat",
+    "panel",
+    "sidebar",
+    "agents"
+  ],
+  "author": {
+    "name": "Prakash Chokalingam",
+    "github": "prakashchokalingam",
+    "url": "https://github.com/prakashchokalingam"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/prakashchokalingam/bb-plugin-bots.git",
+      "range": "^1.0.0"
+    }
+  }
+}

--- a/icons/bots-48f12e36.svg
+++ b/icons/bots-48f12e36.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M13 7H11C8.19108 7 6.78661 7 5.77772 7.67412C5.34096 7.96596 4.96596 8.34096 4.67412 8.77772C4 9.78661 4 11.1911 4 14C4 16.8089 4 18.2134 4.67412 19.2223C4.96596 19.659 5.34096 20.034 5.77772 20.3259C6.78661 21 8.19108 21 11 21H13C15.8089 21 17.2134 21 18.2223 20.3259C18.659 20.034 19.034 19.659 19.3259 19.2223C20 18.2134 20 16.8089 20 14C20 11.1911 20 9.78661 19.3259 8.77772C19.034 8.34096 18.659 7.96596 18.2223 7.67412C17.2134 7 15.8089 7 13 7Z" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+  <path d="M4 14H2" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+  <path d="M10 17H14" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+  <path d="M22 14H20" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+  <path d="M15 11V13" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+  <path d="M9 11V13" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+  <path d="M12 7C12 5.11438 12 4.17157 11.4142 3.58579C10.8284 3 9.88562 3 8 3" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+</svg>


### PR DESCRIPTION
## What the plugin does

Bots adds a **Bots** row to the BB sidebar. Each bot has a name, an emoji
icon, its own instructions, a provider, model and reasoning level, and an
optional project. Opening a bot drops you into its newest chat, or a fresh
composer if it has none.

Bots are created as **drafts** and autosave every keystroke; publishing is
blocked until the bot has a name, a provider and a model, and the server
rejects `startChat` for a draft rather than relying on the UI to hide it.

The persona is applied through `bb.agents.contributeInstructions()`, which
BB evaluates at `thread.start` and `turn.submit`. The plugin maps a chat
thread back to its bot and returns that bot's instruction block, and returns
`null` for every other thread in BB — so a persona never leaks outside its
own chats. Both the hit and the `null` fallthrough are pinned by tests.

Chats are ordinary visible BB threads, so they can be opened, archived and
deleted like any other. Both chat surfaces are host-owned: the transcript is
BB's own `ThreadChat` and the first-message box is BB's own
`experimental_NewThreadComposer`. The plugin reimplements neither.

See the README screenshots for what the Bots panel looks like in BB.

## Source release

- Repository: https://github.com/prakashchokalingam/bb-plugin-bots (public, MIT)
- Release: annotated tag `v1.1.0`, repository root, no `tagPrefix`
- Entry source: `git.range = "^1.0.0"` already covers `v1.1.0`, so the entry
  JSON is unchanged
- Package manifest: `bb-plugin-bots@1.1.0`, `engines.bb >=0.39.0`,
  `engines.bbPluginSdk >=0.4.8`

## Plugin checks

- `vitest run` — 77 tests across 3 files, all passing
- `tsc --noEmit` — clean, `strict: true`, `skipLibCheck: false`
- `bb plugin build` — builds `dist/server.js` and `dist/app.js` + `app.css`
  from source; no build output is committed

## Marketplace checks

- `npm ci --ignore-scripts && npm run build` — passes
- `npm run check` (liveness against the public tag) — passes
- Icon vendored at `icons/bots-48f12e36.svg` (1304 bytes, filename carries
  the sha256 prefix of the source SVG); no remote icon reference

## Permissions and external services

The plugin makes **no network calls of its own** and contacts no external
service. It persists bots in a plugin-local SQLite database and holds two
in-memory maps as the read path, because `contributeInstructions` is a
synchronous callback on the thread-start path. Model inference happens
entirely through BB's existing provider plumbing via `threads.spawn` — the
plugin holds no API keys and stores no credentials.
