### PR TITLE
Publish install counts as a stats.json sidecar

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -1,0 +1,32 @@
+name: Publish install counts
+on:
+  workflow_dispatch:
+  schedule:
+    # Daily. The store reads a rounded "1.2k installs"; a fresher number would
+    # not change what anyone sees, and each run is a full PostHog scan.
+    - cron: "17 6 * * *"
+jobs:
+  stats:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - run: npm ci
+      # Fails, and uploads nothing, when PostHog answers with no counts: the
+      # last published sidecar keeps serving rather than being zeroed out.
+      - name: Build stats.json
+        env:
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          POSTHOG_PROJECT_ID: ${{ vars.POSTHOG_PROJECT_ID }}
+          POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
+        run: npm run build:stats
+      - name: Upload stats.json
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          npx wrangler@4 r2 object put "bb-marketplace/stats.json" \
+            --file dist/stats.json \
+            --content-type application/json --remote

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ installation refreshes.
   <https://getbb.app/schemas/marketplace.schema.json>.
 - `scripts/build.mjs` — validates everything and composes
   `dist/marketplace.json` deterministically.
+- `scripts/build-stats.mjs` — composes `dist/stats.json`, the install-count
+  sidecar, from BB's `plugin_installed` telemetry.
 
 ## Submit a plugin
 
@@ -36,6 +38,48 @@ The account that opens the listing pull request is recorded as the owner in
 BB installs nothing automatically: a catalog refresh only surfaces
 `bb plugin outdated`, and applying an update is a manual, staged,
 rollback-protected action.
+
+## Install counts
+
+`https://getbb.app/marketplace/v1/stats.json` publishes how many distinct BB
+installations reported installing each public plugin. BB fetches it beside the
+manifest on every catalog refresh and shows the number on the store card, the
+mobile browse row, and `bb plugin search`.
+
+```json
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-21T06:17:00.000Z",
+  "plugins": { "thread-hover-cards": { "installs": 4210 } }
+}
+```
+
+- The counts come from the `plugin_installed` event that BB servers already
+  send to PostHog. Telemetry is opt-out and only reports from production
+  builds, so a count is "installs BB heard about", not a true total.
+- It is a separate document, not a field in `marketplace.json`. That schema is
+  strict, so an unknown field there rejects the whole catalog on an older
+  desktop, and the numbers move daily while the manifest sits unchanged behind
+  a 304.
+- Bundled BB plugins appear here too, even though they have no entry in
+  `entries/`: BB looks their counts up in this same document.
+- Only this marketplace publishes counts. BB ignores a `stats.json` beside a
+  third-party manifest, because the number is BB's measurement, not the
+  publisher's claim.
+- `.github/workflows/stats.yml` rebuilds and uploads it daily. It needs the
+  `POSTHOG_API_KEY` secret (a personal API key with project read access) and
+  the `POSTHOG_PROJECT_ID` variable, alongside the Cloudflare credentials the
+  manifest publish already uses. Set `POSTHOG_HOST` when the project is not on
+  US cloud.
+- A run that finds no counts fails without uploading, so an outage or a
+  rotated key leaves the last published sidecar in place instead of zeroing
+  every counter in the store.
+
+Print the document without publishing it:
+
+```sh
+POSTHOG_API_KEY=… POSTHOG_PROJECT_ID=… node scripts/build-stats.mjs --print
+```
 
 ## Local validation
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "engines": { "node": ">=20" },
   "scripts": {
     "build": "node scripts/build.mjs",
+    "build:stats": "node scripts/build-stats.mjs",
     "check": "node scripts/build.mjs --liveness"
   },
   "devDependencies": {

--- a/scripts/build-stats.mjs
+++ b/scripts/build-stats.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+// Compose dist/stats.json: the install-count sidecar BB reads beside
+// marketplace.json. Counts come from the `plugin_installed` telemetry event
+// every BB server already sends, queried through PostHog's HogQL API.
+//
+// The counts do not live in marketplace.json on purpose. That schema is
+// strict, so an unknown field there rejects the whole catalog on an older
+// desktop; and the numbers move daily while the manifest sits unchanged
+// behind a 304, which would make every count refresh a full catalog rewrite.
+//
+// Environment:
+//   POSTHOG_API_KEY     personal API key with project read access (secret)
+//   POSTHOG_PROJECT_ID  numeric project id
+//   POSTHOG_HOST        defaults to https://us.posthog.com
+//   GENERATED_AT        ISO timestamp to stamp; defaults to now
+//
+// `--print` writes the document to stdout instead of dist/stats.json.
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = new URL("..", import.meta.url).pathname;
+const printOnly = process.argv.includes("--print");
+
+/** Same id shape the marketplace schema requires of an entry. */
+const ENTRY_ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+
+/** A hostile or broken answer must not become a 100 MB sidecar. */
+const MAX_ENTRIES = 5_000;
+
+/**
+ * Distinct BB installations that reported installing each public plugin.
+ *
+ * Distinct, not raw event count: one person reinstalling a plugin ten times
+ * while debugging is one install of it, and a raw count would let anyone
+ * inflate their own listing from a loop.
+ *
+ * Telemetry only carries `plugin_id` for public plugins — bundled builtins and
+ * bb-community entries — and sends null for direct and third-party installs,
+ * so no private plugin id or source can reach this file. Bundled builtins are
+ * counted too even though they have no entry here: BB looks them up in this
+ * same document.
+ */
+const QUERY = `
+  SELECT properties.plugin_id AS plugin_id,
+         count(DISTINCT distinct_id) AS installs
+  FROM events
+  WHERE event = 'plugin_installed'
+    AND properties.plugin_id IS NOT NULL
+    AND properties.plugin_id != ''
+  GROUP BY plugin_id
+  ORDER BY installs DESC
+  LIMIT ${MAX_ENTRIES}
+`;
+
+function required(name) {
+  const value = process.env[name];
+  if (value === undefined || value.trim().length === 0) {
+    console.error(`error: ${name} is not set`);
+    process.exit(1);
+  }
+  return value.trim();
+}
+
+async function queryInstallCounts() {
+  const host = (process.env.POSTHOG_HOST ?? "https://us.posthog.com").replace(
+    /\/+$/,
+    "",
+  );
+  const projectId = required("POSTHOG_PROJECT_ID");
+  const response = await fetch(`${host}/api/projects/${projectId}/query/`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${required("POSTHOG_API_KEY")}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      query: { kind: "HogQLQuery", query: QUERY },
+    }),
+    signal: AbortSignal.timeout(120_000),
+  });
+  if (!response.ok) {
+    // The body names the real problem (bad key, wrong project, HogQL error).
+    const detail = await response.text().catch(() => "");
+    throw new Error(
+      `PostHog query failed with HTTP ${response.status}: ${detail.slice(0, 500)}`,
+    );
+  }
+  const body = await response.json();
+  if (!Array.isArray(body?.results)) {
+    throw new Error("PostHog answer has no results array");
+  }
+  return body.results;
+}
+
+/** Rows PostHog returns are `[plugin_id, installs]`; drop anything else. */
+function pluginsFromRows(rows) {
+  const plugins = {};
+  let dropped = 0;
+  for (const row of rows) {
+    const [id, installs] = Array.isArray(row) ? row : [];
+    if (
+      typeof id !== "string" ||
+      !ENTRY_ID_PATTERN.test(id) ||
+      typeof installs !== "number" ||
+      !Number.isSafeInteger(installs) ||
+      installs < 0
+    ) {
+      dropped += 1;
+      continue;
+    }
+    plugins[id] = { installs };
+  }
+  if (dropped > 0) {
+    console.error(`warning: dropped ${dropped} unusable row(s) from PostHog`);
+  }
+  // Sorted keys keep the published document byte-stable between runs that
+  // return the same counts, so an unchanged sidecar keeps its ETag.
+  return Object.fromEntries(
+    Object.keys(plugins)
+      .sort()
+      .map((id) => [id, plugins[id]]),
+  );
+}
+
+let rows;
+try {
+  rows = await queryInstallCounts();
+} catch (error) {
+  // A rejected top-level await prints an undici stack trace; the job log
+  // should name the problem instead.
+  console.error(`error: ${error instanceof Error ? error.message : error}`);
+  process.exit(1);
+}
+const plugins = pluginsFromRows(rows);
+// Publishing an empty document would silently zero every counter in the
+// store. An outage, a rotated key, or a renamed event must fail the job
+// instead, leaving the last good sidecar in place.
+if (Object.keys(plugins).length === 0) {
+  console.error("error: PostHog returned no usable install counts");
+  process.exit(1);
+}
+
+const document = {
+  schemaVersion: 1,
+  generatedAt: process.env.GENERATED_AT ?? new Date().toISOString(),
+  plugins,
+};
+const bytes = `${JSON.stringify(document, null, 2)}\n`;
+
+if (printOnly) {
+  process.stdout.write(bytes);
+} else {
+  mkdirSync(join(root, "dist"), { recursive: true });
+  writeFileSync(join(root, "dist", "stats.json"), bytes);
+  console.log(
+    `built dist/stats.json with ${Object.keys(plugins).length} counted plugins`,
+  );
+}


### PR DESCRIPTION
## What was wrong

BB servers have sent a `plugin_installed` telemetry event since the store shipped, but nothing ever read it back. The registry had no way to tell anyone how many people use a listing, and the store card had no popularity signal at all.

## What changed

- `scripts/build-stats.mjs` (new, `npm run build:stats`) queries PostHog's HogQL API for `count(DISTINCT distinct_id)` of `plugin_installed` grouped by `properties.plugin_id` and writes `dist/stats.json`.
  - Distinct installations, not raw events: a reinstall loop must not inflate a listing.
  - Rows whose id fails the manifest's own id pattern, or whose count is not a non-negative safe integer, are dropped with a warning. Keys are emitted sorted, so an unchanged run republishes identical bytes and keeps its ETag.
  - A run that ends with no usable counts exits non-zero **without writing**, so an outage or a rotated key leaves the last published sidecar serving rather than zeroing every counter in the store.
  - `--print` writes to stdout for local inspection.
- `.github/workflows/stats.yml` (new) runs it daily plus on demand and uploads to `bb-marketplace/stats.json` in the same bucket as the manifest publish.
- README documents the format, the undercount caveat, and the required credentials.

Counts are a separate document rather than a field in `marketplace.json` on purpose: that schema is strict, so an unknown field there rejects the whole catalog on an older desktop, and the numbers move daily while the manifest sits unchanged behind a 304.

**Deploy requirement:** the `production` environment needs a new `POSTHOG_API_KEY` secret (a personal API key with project read access) and a `POSTHOG_PROJECT_ID` variable. Set `POSTHOG_HOST` if the project is not on US cloud. Until they exist the scheduled job fails and uploads nothing; the manifest publish is unaffected.

The consuming side is get-bb/bb: the server fetches this file on every catalog refresh and renders the number in the store, on mobile, and in `bb plugin search`.

## How you verified

- Ran the script against a stub PostHog endpoint: confirmed the request carries the bearer key and the HogQL body, that a bad id and a non-numeric count are both dropped with a warning, and that the output has sorted keys and a stamped `generatedAt`.
- Fed that exact output through BB's own `parseMarketplaceStatsJson` in a scratch test in the bb checkout — it parses and reports the right count.
- Confirmed an empty result set exits 1 without writing `dist/stats.json`.
- `npm run build` still composes the manifest unchanged (63 entries).

Not run: the workflow itself, which needs the credentials above.

Fixes #

> AGENT GENERATED