### PR TITLE
Track floating-terminal v0.5.0

### DIFF
--- a/entries/floating-terminal.json
+++ b/entries/floating-terminal.json
@@ -21,7 +21,7 @@
   "source": {
     "git": {
       "url": "https://github.com/vburojevic/bb-plugin-floating-terminal.git",
-      "range": "^0.4.0"
+      "range": "^0.5.0"
     }
   }
 }


### PR DESCRIPTION
Bumps `floating-terminal` from `^0.4.0` to `^0.5.0` — a caret range on `0.x` is
minor-locked, so the listing cannot see v0.5.0 without this.

## What v0.5.0 adds

A polish pass over the whole plugin:

- **Find in scrollback** — Cmd/Ctrl+F inside the terminal (or a `find` key on
  the mobile bar): highlighted matches, counts, Enter/Shift+Enter navigation.
- **Jump to latest** — a pill appears when the view is parked in history, and
  never in the alternate screen.
- **Maximize/restore** on desktop (button + titlebar double-click), and
  middle-click closes a tab.
- Touch targets: on a coarse pointer the tab strip grows to 48px with an
  always-visible close control.
- xterm's scrollbar slider now themed from bb's tokens; fling honours
  `prefers-reduced-motion`; `^R` added to the mobile key bar.

## Checks

- 77 unit tests, typecheck, `bb plugin build`
- Fresh `git clone --branch v0.5.0` + `npm install --omit=dev` + build
- 5-configuration mobile matrix (Galaxy S9+, iPhone 14 Pro, Pixel 7, iPhone
  under WebKit, iPad Pro 11) — twice, plus desktop geometry regression scripts
- All features runtime-verified against a live pty

No new permissions, services, or network access. One new bundled dependency:
`@xterm/addon-search` (MIT, same xterm.js project as the terminal itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
