### PR TITLE
Add plugin entry: linear

### DIFF
--- a/entries/linear.json
+++ b/entries/linear.json
@@ -23,7 +23,7 @@
   "source": {
     "git": {
       "url": "https://github.com/vburojevic/bb-plugin-linear.git",
-      "range": "^0.1.2"
+      "range": "^0.1.3"
     }
   }
 }

--- a/entries/linear.json
+++ b/entries/linear.json
@@ -1,0 +1,29 @@
+{
+  "id": "linear",
+  "displayName": "Linear",
+  "description": "Linear inside bb — a list-first issue browser, inbox, and create dialog served from a local mirror, thirteen linear_* agent tools, a bb linear CLI, and every thread resolving which issue it works on, shown live in the header and side panel and injected into agent context.",
+  "icon": {
+    "url": "./icons/linear-6ff21144.svg"
+  },
+  "tags": [
+    "linear",
+    "issues",
+    "issue-tracking",
+    "inbox",
+    "agent-tools",
+    "threads",
+    "cli",
+    "sync"
+  ],
+  "author": {
+    "name": "Vedran Burojevic",
+    "github": "vburojevic",
+    "url": "https://github.com/vburojevic"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/vburojevic/bb-plugin-linear.git",
+      "range": "^0.1.2"
+    }
+  }
+}

--- a/icons/linear-6ff21144.svg
+++ b/icons/linear-6ff21144.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <!-- The half-filled "In Progress" disc — the same state glyph the panel
+       draws on every issue row, so the plugin's icon speaks the UI's own
+       language. Shape-only on purpose: bb masks panel icons to a single
+       color, so the silhouette must carry the mark by itself. -->
+  <g stroke="#5E6AD2" stroke-width="2.2" fill="none">
+    <circle cx="12" cy="12" r="8.6"/>
+    <path d="M12 7.2 A 4.8 4.8 0 0 1 12 16.8 Z" fill="#5E6AD2" stroke="none"/>
+  </g>
+</svg>


### PR DESCRIPTION
## What the plugin does

Linear inside bb: a list-first issue browser in the nav panel (state groups, filters, full-text search, keyboard navigation, inbox with badge, two-field create dialog) served from a local SQLite mirror; a deterministic ladder that resolves which Linear issue each bb thread is working on (explicit link > Linear branch name > issue key in conversation > fuzzy suggestion that asks, never binds), shown live in the thread header and side panel and injected into agent instructions; thirteen `linear_*` agent tools plus a `bb linear` CLI, identical across providers.

## Source release

- `https://github.com/vburojevic/bb-plugin-linear.git`, range `^0.1.2` (annotated tag `v0.1.2`, public)
- Installs from source: bb clones, installs dependencies, builds on the user's machine — nothing pre-built ships in the repo

## Plugin checks

- `tsc --noEmit` clean, 742 tests passing (vitest), `bb plugin build` succeeds
- A machine-local pre-push hook runs the same gate on every push

## Marketplace checks

- `npm run build` and `npm run check` both pass (64 entries)
- Icon vendored as `icons/linear-6ff21144.svg` (sha256-prefixed, shape-only SVG, no scripts or remote resources)

## Security facts for reviewers

- Credential: a personal Linear API key per workspace, stored in bb's secret store, redacted from every error, log line, tool result and rpc payload at construction
- One consent switch ("Allow changes to Linear") gates every mutation at the single transport door; refusals name the switch
- Every GraphQL document is validated offline against a vendored SDL by the test suite; rate-limit headers are honored with a budget
- Webhooks are optional: registered only after a signed self-test, demoted back to polling on delivery failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
