### PR TITLE
Add plugin entry: pdf-viewer

### DIFF
--- a/entries/pdf-viewer.json
+++ b/entries/pdf-viewer.json
@@ -1,0 +1,30 @@
+{
+  "id": "pdf-viewer",
+  "displayName": "PDF Viewer",
+  "description": "Opens .pdf files in a BB panel tab instead of downloading them, with the browser's paging, zoom, search and print controls, and adds a PDF panel for browsing a host's folders and reopening recent documents.",
+  "icon": {
+    "url": "./icons/pdf-viewer-8ac376f7.svg"
+  },
+  "tags": [
+    "pdf",
+    "documents",
+    "viewer",
+    "file-opener",
+    "files",
+    "reader",
+    "interface"
+  ],
+  "author": {
+    "name": "Foma",
+    "github": "xMinor-1",
+    "url": "https://github.com/xMinor-1"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/xMinor-1/bb-plugins.git",
+      "subdir": "plugins/pdf-viewer",
+      "range": "^0.1.0",
+      "tagPrefix": "pdf-viewer/"
+    }
+  }
+}

--- a/icons/pdf-viewer-8ac376f7.svg
+++ b/icons/pdf-viewer-8ac376f7.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M6.5 2h7.09a1.5 1.5 0 0 1 1.06.44l5.41 5.41A1.5 1.5 0 0 1 20.5 8.9V19.5A2.5 2.5 0 0 1 18 22H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2Zm7.75 2.56V8a.75.75 0 0 0 .75.75h3.44l-4.19-4.19ZM8 12.25h8v1.75H8v-1.75Zm0 4h5.25v1.75H8v-1.75Z"/>
+</svg>


### PR DESCRIPTION
## What the plugin does

PDF Viewer makes PDFs readable inside BB instead of downloading them:

- Registers a `fileOpener` for the `pdf` extension, so a PDF linked from a
  message, picked in the file picker, or opened with `bb thread open` renders
  in a panel tab with the browser's own paging, zoom, search and print.
- Adds a **PDF** nav panel that browses a host's folders (only folders and
  PDFs are listed) and reopens recent documents. Recents are stored in the
  plugin's own KV and can be turned off with a boolean setting.

## Source release

- `git:https://github.com/xMinor-1/bb-plugins.git`, `subdir plugins/pdf-viewer`
- Tag `pdf-viewer/v0.1.0` (`tagPrefix: "pdf-viewer/"`), range `^0.1.0`
- Manifest engines: `bb >=0.39`, `bbPluginSdk >=0.4.8`

## Plugin checks

- `npm test` — 13 vitest cases (range parsing, `Content-Disposition` encoding,
  the document registry's expiry and sweeping, path helpers)
- `npx tsc --noEmit` — clean
- `bb plugin build .` — clean, and the plugin runs on bb 0.39.0
- Verified against real files: a 5 MB PDF with a Cyrillic filename, and a
  36 MB file to exercise the streaming path and `Range` responses

## Marketplace checks

- `npm ci --ignore-scripts`, `npm run build`, `npm run check` all succeed
- Icon vendored to `icons/pdf-viewer-8ac376f7.svg` (SVG, 380 bytes, no scripts
  or remote references)

## Notes for reviewers

Two transports, chosen by size:

- **Below 25 MB** the plugin uses `bb.sdk.files.createPreview`, confined to the
  document's own directory and leased for an hour. This is the default because
  it is BB's native transport: it reaches other connected hosts and keeps
  working when the app is opened remotely.
- **Above that ceiling** (where the preview route returns 413) a document on
  the server's own host is served by the plugin's own `local`-auth GET route
  with `Range` support. That route never accepts a path from the client: the
  backend registers the resolved document in an in-memory registry and the URL
  carries only an opaque id that expires after an hour. Host locality is
  established by comparing against the host id in BB's data directory, so a
  same-looking path on a different host is never read from local disk.

No external services, no network calls, no credentials. The plugin reads files
the user asks for through BB's own file APIs and, for oversized local
documents, `node:fs` read streams.
