### PR TITLE
Add System Tools plugin

### DIFF
--- a/entries/system-tools.json
+++ b/entries/system-tools.json
@@ -1,0 +1,26 @@
+{
+  "id": "system-tools",
+  "displayName": "System Tools",
+  "description": "Monitor and safely manage files, cleanup, processes, ports, storage, and host health from a BB sidebar page.",
+  "icon": "Laptop",
+  "tags": [
+    "system",
+    "monitoring",
+    "cleanup",
+    "processes",
+    "ports",
+    "storage",
+    "files"
+  ],
+  "author": {
+    "name": "Yusuf Lisawi",
+    "github": "YusufLisawi",
+    "url": "https://github.com/YusufLisawi"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/YusufLisawi/bb-plugin-system-tools.git",
+      "range": "^0.1.0"
+    }
+  }
+}


### PR DESCRIPTION
Adds System Tools, a public BB plugin for host monitoring and guarded machine management. It includes CPU, RAM, storage, file browser and cleanup scanning, process controls, and protected non-critical port termination. The plugin is released from https://github.com/YusufLisawi/bb-plugin-system-tools at v0.1.0. Validation passed: plugin typecheck, plugin build, BB plugin type check, marketplace build, and marketplace liveness check.