### PR TITLE
Add plugin entry: provider-usage

### DIFF
--- a/entries/provider-usage.json
+++ b/entries/provider-usage.json
@@ -1,7 +1,7 @@
 {
   "id": "provider-usage",
   "displayName": "Provider Usage",
-  "description": "Shows how much of each provider's plan is left — every rate-limit window, percent remaining, and when it resets — alongside 7/30/90-day token volume read from local Codex, Claude Code, and Cursor transcripts.",
+  "description": "Shows how much of each provider's plan is left — every rate-limit window, percent remaining, and when it resets — alongside 7/30/90-day token volume read from local Codex, Claude Code, Cursor, and opencode transcripts.",
   "icon": {
     "url": "./icons/provider-usage-752e444b.svg"
   },
@@ -13,6 +13,7 @@
     "codex",
     "claude-code",
     "cursor",
+    "opencode",
     "sidebar"
   ],
   "author": {
@@ -23,7 +24,7 @@
   "source": {
     "git": {
       "url": "https://github.com/braedonsaunders/bb-plugin-provider-usage.git",
-      "range": "^0.2.0"
+      "range": "^0.3.0"
     }
   }
 }

--- a/entries/provider-usage.json
+++ b/entries/provider-usage.json
@@ -1,0 +1,29 @@
+{
+  "id": "provider-usage",
+  "displayName": "Provider Usage",
+  "description": "Shows how much of each provider's plan is left — every rate-limit window, percent remaining, and when it resets — alongside 7/30/90-day token volume read from local Codex, Claude Code, and Cursor transcripts.",
+  "icon": {
+    "url": "./icons/provider-usage-752e444b.svg"
+  },
+  "tags": [
+    "usage",
+    "rate-limits",
+    "quota",
+    "tokens",
+    "codex",
+    "claude-code",
+    "cursor",
+    "sidebar"
+  ],
+  "author": {
+    "name": "Braedon Saunders",
+    "github": "braedonsaunders",
+    "url": "https://github.com/braedonsaunders"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/braedonsaunders/bb-plugin-provider-usage.git",
+      "range": "^0.2.0"
+    }
+  }
+}

--- a/entries/provider-usage.json
+++ b/entries/provider-usage.json
@@ -1,7 +1,7 @@
 {
   "id": "provider-usage",
   "displayName": "Provider Usage",
-  "description": "Shows how much of each provider's plan is left — every rate-limit window, percent remaining, and when it resets — alongside 7/30/90-day token volume read from local Codex, Claude Code, Cursor, and opencode transcripts.",
+  "description": "Shows how much of each provider's plan is left — every rate-limit window, percent remaining, and when it resets — plus a 7/30/90-day token chart covering every provider, from local transcripts and BB's own usage events.",
   "icon": {
     "url": "./icons/provider-usage-752e444b.svg"
   },
@@ -24,7 +24,7 @@
   "source": {
     "git": {
       "url": "https://github.com/braedonsaunders/bb-plugin-provider-usage.git",
-      "range": "^0.3.0"
+      "range": "^0.4.0"
     }
   }
 }

--- a/icons/provider-usage-752e444b.svg
+++ b/icons/provider-usage-752e444b.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path
+    d="M4.4 15.2a8.2 8.2 0 1 1 15.2 0"
+    stroke="currentColor"
+    stroke-width="1.8"
+    stroke-linecap="round"
+  />
+  <path
+    d="M12 14.6V9.8L16 8.4"
+    stroke="currentColor"
+    stroke-width="1.8"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M5.5 18.6h13"
+    stroke="currentColor"
+    stroke-width="1.8"
+    stroke-linecap="round"
+  />
+</svg>


### PR DESCRIPTION
## What it does

A BB panel for how much of each provider's plan is left, and how many tokens you are actually burning.

- **Subscription windows** — one card per signed-in provider with its plan and every rate-limit window it reports (5-hour, weekly, monthly), percent used, percent remaining, and reset time, colour-toned so a nearly-exhausted window is obvious.
- **Headline metrics** — providers signed in, cumulative remaining, the single tightest window right now, and the next reset.
- **Token volume** — a 7/30/90-day multi-series chart of real token counts read off local transcripts: Codex (`~/.codex` / `$CODEX_HOME`), Claude Code (`~/.claude` / `$CLAUDE_CONFIG_DIR`), and Cursor's ACP session stores, split into total / input / output / cached per provider.
- **Multi-machine** — a picker switches the whole view between paired hosts.
- Contributes a nav panel, a homepage section, a sidebar accessory, a `bb usage` CLI, and a `usage` skill so a long-running thread can decide whether to keep going or wait for a reset.

### How it differs from the existing usage entries

`usage`, `usage-page`, and `usage-tracker` all lead with token spend and estimated API cost. This one leads with **remaining plan quota and reset windows** across every provider at once, and reports token volume without pricing it. Its id is `provider-usage` precisely because `usage` is taken.

## Source release

`git` semver range `^0.2.0` over `https://github.com/braedonsaunders/bb-plugin-provider-usage.git`.

Tag `v0.2.0` → `5432c390bca41fe580142a9443c90780f7a16da3`. Repository root, no `subdir`.

## Plugin checks

- `npx tsc --noEmit` — clean.
- `bb plugin build` — server + app bundles emit.
- Installed from path and exercised live on macOS: panel renders, `bb usage` and `bb usage tokens --days 7` return real data, `token-scan` service runs.

## Marketplace checks

- `npm ci --ignore-scripts`, `npm run build`, `npm run check` — all pass; 65 entries composed, liveness confirms the tag resolves.
- Entry id `provider-usage` matches the filename and the id derived from the package name `bb-plugin-provider-usage`.
- Icon vendored at `icons/provider-usage-752e444b.svg` (463 B, content-hashed, no scripts or remote references).

## Permissions and security

- **No network egress of its own.** Subscription windows come from BB's `system.usageLimits`; there are no vendor API keys and nothing is uploaded.
- **Local reads only**, and only transcript metadata: token counts and timestamps from `~/.codex`, `~/.claude`, and Cursor's ACP stores. Message content is not read into the panel or stored.
- **Storage** — one plugin-local SQLite database caching per-file scan results, so re-syncs only re-read files whose size or mtime changed.
- **Background work** — a single `token-scan` service on a 15-minute interval that aborts cleanly on reload/disable.
- Declares `engines.bb >= 0.39`, `bbPluginSdk >= 0.4.8`. MIT licensed.
