### PR TITLE
Add plugin entry: thread-provider-icons

### DIFF
--- a/entries/thread-provider-icons.json
+++ b/entries/thread-provider-icons.json
@@ -1,0 +1,26 @@
+{
+  "id": "thread-provider-icons",
+  "displayName": "Thread Provider Icons",
+  "description": "Draws each thread's provider logo before its title in the sidebar, in the provider's own brand colour, so you can tell which agent owns which thread without opening it.",
+  "icon": {
+    "url": "./icons/thread-provider-icons-1ca4af15.svg"
+  },
+  "tags": [
+    "interface",
+    "sidebar",
+    "threads",
+    "icons",
+    "providers"
+  ],
+  "author": {
+    "name": "Braedon Saunders",
+    "github": "braedonsaunders",
+    "url": "https://github.com/braedonsaunders"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/braedonsaunders/bb-plugin-thread-provider-icons.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/icons/thread-provider-icons-1ca4af15.svg
+++ b/icons/thread-provider-icons-1ca4af15.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <circle cx="5.4" cy="6.4" r="1.9" fill="currentColor" />
+  <rect x="3.6" y="10.2" width="3.6" height="3.6" rx="0.7" fill="currentColor" />
+  <path d="M5.4 15.8l1.9 3.3H3.5z" fill="currentColor" />
+  <path
+    d="M10.4 6.4h10M10.4 12h10M10.4 17.6h6.6"
+    stroke="currentColor"
+    stroke-width="1.8"
+    stroke-linecap="round"
+  />
+</svg>


### PR DESCRIPTION
## What it does

Draws each thread's provider logo before its title in the sidebar.

When you run threads across Codex, Claude Code, Cursor, opencode, Grok and Pi, the sidebar is a wall of identical rows. This puts the agent's own mark in front of every title, in the provider's brand colour, so you can tell at a glance who owns which thread.

- One 14px provider mark per sidebar row, inserted before the title.
- Colours follow the host theme in both light and dark, using the same marks and colour classes as BB's own composer provider picker.
- Unknown `acp-*` agents fall back to the generic ACP mark and are labelled from their provider id, so new agents still get a sensible icon.
- Hover tooltip naming the provider.
- Nothing else: no settings, no panel, no background work, no storage.

It was previously a side feature inside [UltraGoal](https://github.com/braedonsaunders/bb-plugin-ultragoal). It is generic chrome with nothing goal-specific about it, so it now ships on its own; UltraGoal v0.6.0 drops its copy, and the README notes that pairing older UltraGoal with this plugin would double up.

## Source release

`git` semver range `^0.1.0` over `https://github.com/braedonsaunders/bb-plugin-thread-provider-icons.git`.

Tag `v0.1.0` → `170ae0879f29405484c1615b0d7cab54f80d49e3`. Repository root, no `subdir`.

## Plugin checks

- `npx tsc --noEmit` — clean.
- `bb plugin build` — server + app bundles emit.
- Installed from path and exercised live on macOS against threads from four different providers; marks render, update on thread changes, and unmount cleanly on reload.

## Marketplace checks

- `npm ci --ignore-scripts`, `npm run build`, `npm run check` — all pass; 65 entries composed, liveness confirms the tag resolves.
- Entry id `thread-provider-icons` matches the filename and the id derived from the package name `bb-plugin-thread-provider-icons`.
- Icon vendored at `icons/thread-provider-icons-1ca4af15.svg` (414 B, content-hashed, no scripts or remote references).

## Permissions and security

- **Frontend-only.** The server entry exists solely because BB requires one; it logs a line and does nothing else. No storage, no settings, no background services, no network access, no filesystem access.
- Reads only what the host already hands it: thread ids and provider ids from `experimental_useSidebarThreads()`. No thread content is touched.
- **Two things a reviewer should know**, since both are load-bearing:
  - It uses two experimental SDK surfaces (`experimental_threadList`, `experimental_useSidebarThreads`) and depends on the sidebar's DOM shape, so a BB release that reworks the thread list will need a matching release here. The README says so.
  - Its `MutationObserver` watches `document.body`, which is the subtree it also writes to. It disconnects while writing and coalesces on an animation frame — without that it re-triggers itself and wedges the main thread. That guard is commented in the source.
- Declares `engines.bb >= 0.39`, `bbPluginSdk >= 0.4.8`. MIT licensed.
