### PR TITLE
Add plugin entry: usage-circles

### DIFF
--- a/entries/usage-circles.json
+++ b/entries/usage-circles.json
@@ -1,0 +1,22 @@
+{
+  "id": "usage-circles",
+  "displayName": "Usage Circles",
+  "description": "Displays Claude Code usage limits as paired rings in the BB sidebar footer — an outer ring for share spent that colors by threshold and an inner ring for time until reset — and expands a per-window breakdown panel on click.",
+  "icon": {
+    "url": "./icons/usage-circles-c71462e8.svg"
+  },
+  "tags": ["usage", "limits", "quota", "claude-code", "sidebar", "footer", "rings"],
+  "author": {
+    "name": "e0068",
+    "github": "e0068",
+    "url": "https://github.com/e0068"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/e0068/bb-plugins.git",
+      "subdir": "bb-plugin-usage-circles",
+      "range": "^0.1.0",
+      "tagPrefix": "usage-circles/"
+    }
+  }
+}

--- a/icons/usage-circles-c71462e8.svg
+++ b/icons/usage-circles-c71462e8.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" color="#000">
+  <g transform="rotate(-90 12 12)" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+    <circle cx="12" cy="12" r="9" stroke-dasharray="39.58 16.97"/>
+    <circle cx="12" cy="12" r="6" stroke-dasharray="20.73 16.97"/>
+    <circle cx="12" cy="12" r="3" stroke-dasharray="16.96 1.89"/>
+  </g>
+</svg>


### PR DESCRIPTION
## What the plugin does
Usage Circles displays Claude Code usage limits as paired rings in the BB sidebar footer: an outer ring for the share spent (colored by threshold — blue under 60%, yellow from 60%, red from 90%) and an inner ring for time until the window resets. Clicking expands a per-window breakdown panel (label, percent, spend bar, time bar, reset time). Data comes from BB's own `bb.sdk.system.usageLimits()`.

## Source release
- Repository: `https://github.com/e0068/bb-plugins.git`
- Subdir: `bb-plugin-usage-circles` (multi-plugin repo)
- Release tag: `usage-circles/v0.1.0` → commit `82e4283`
- Selected range: `^0.1.0` with `tagPrefix: usage-circles/`

## Plugin checks (passed)
- `tsc --noEmit` — clean
- `vitest run` — 43 tests passed
- `bb plugin build` — built dist server + app

## Marketplace checks (passed)
- `npm run build` — schema validation + compose (64 entries)
- `npm run check` — source liveness: tag resolves for range `^0.1.0`

## Permissions / external services
The plugin reads usage data through BB's SDK (`bb.sdk.system.usageLimits()`); it does not parse Claude Code files directly. A TTL cache coalesces parallel calls in front of the account endpoint to respect its rate limit. No secrets, no external network calls of its own.
