### PR TITLE
Add plugin entry: audio-preview

### DIFF
--- a/entries/audio-preview.json
+++ b/entries/audio-preview.json
@@ -1,0 +1,26 @@
+{
+  "id": "audio-preview",
+  "displayName": "Audio Preview",
+  "description": "Plays .m4a and other audio files in BB's file panel, including audio/mp4 that the built-in preview refuses.",
+  "icon": {
+    "url": "./icons/audio-preview-897ab0d2.svg"
+  },
+  "tags": [
+    "audio",
+    "preview",
+    "files",
+    "interface",
+    "m4a"
+  ],
+  "author": {
+    "name": "Braedon Saunders",
+    "github": "braedonsaunders",
+    "url": "https://github.com/braedonsaunders"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/braedonsaunders/bb-plugin-audio-preview.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/icons/audio-preview-897ab0d2.svg
+++ b/icons/audio-preview-897ab0d2.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path
+    d="M5 9.2h2.8L12 6v12l-4.2-3.2H5A1.4 1.4 0 0 1 3.6 13.4v-2.8A1.4 1.4 0 0 1 5 9.2z"
+    fill="currentColor"
+  />
+  <path
+    d="M15.4 9c1.1.9 1.8 2.1 1.8 3.5s-.7 2.6-1.8 3.5M17.8 6.8c2 1.5 3.2 3.6 3.2 5.7s-1.2 4.2-3.2 5.7"
+    stroke="currentColor"
+    stroke-width="1.8"
+    stroke-linecap="round"
+  />
+</svg>


### PR DESCRIPTION
## What it does

Plays audio files in BB's file panel.

BB's built-in preview refuses `audio/mp4` — the MIME type for `.m4a` — so opening a track shows "Preview not available". This plugin registers as the opener for common audio extensions and renders an HTML5 player instead.

- Opens `.m4a`, `.mp3`, `.wav`, `.ogg`, `.flac`, `.aac`, and similar audio files in a playable preview tab.
- Serves the file through BB's host preview URL, then falls back to a correctly-typed blob (`audio/mp4` for `.m4a`) if the browser cannot decode the stream.
- Works for workspace files, absolute host paths, and thread-storage files.
- Leaves `.mp4` and `.webm` to BB — those containers are often video.
- No settings, no sidebar, no background work.

## Source release

`git` semver range `^0.1.0` over `https://github.com/braedonsaunders/bb-plugin-audio-preview.git`.

Tag `v0.1.0` → `a0c90ec6cb328f2c9f5288526146187e004a51b5`. Repository root, no `subdir`.

## Plugin checks

- `npm test` — 4 passing (MIME map, preview URL joining, path confinement, clocks).
- `npx tsc --noEmit` — clean.
- `bb plugin build` — server + app bundles emit.
- Installed from path and exercised live: `.m4a` and `.mp3` files opened in the file panel and played. The first prepare path failed on `ttlMs > 3600000`; that is now capped at one hour and preview URLs succeed.

## Marketplace checks

- `npm ci --ignore-scripts`, `npm run build`, `npm run check` — all pass; 64 entries composed, liveness confirms the tag resolves.
- Entry id `audio-preview` matches the filename and the id derived from the package name `bb-plugin-audio-preview`.
- Icon vendored at `icons/audio-preview-897ab0d2.svg` (395 B, content-hashed, no scripts or remote references).

## Permissions and security

- Reads audio files the user already opened, through `bb.sdk.files` with `rootPath` confinement. Relative paths reject `..`.
- Preview URLs are temporary, path-shaped, and do not expose the host id or absolute root.
- The blob fallback loads the file bytes into the renderer so the player can set the correct MIME. Typical music files are under a few MB; there is no write path.
- No settings, no storage, no background services, no outbound network.
- Declares `engines.bb >= 0.39`, `bbPluginSdk >= 0.4.8`. MIT licensed.
