### PR TITLE
Add plugin entry: git-history

### DIFF
--- a/entries/git-history.json
+++ b/entries/git-history.json
@@ -1,0 +1,18 @@
+{
+  "id": "git-history",
+  "displayName": "Git History",
+  "description": "Shows the complete Git history of a project as a compact commit graph with changed files and per-file diffs.",
+  "icon": "FolderGit",
+  "tags": ["git", "history", "version-control", "diffs", "interface"],
+  "author": {
+    "name": "Yusuf Akbulut",
+    "github": "yusuf8834",
+    "url": "https://github.com/yusuf8834"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/yusuf8834/bb-git-history.git",
+      "range": "^0.1.0"
+    }
+  }
+}


### PR DESCRIPTION
## What it does

Git History adds a compact, read-only commit graph to each bb thread. It reads every Git ref, expands changed files inline, and uses bb's native renderer for per-file diffs.

## Source release

- Repository: `https://github.com/yusuf8834/bb-git-history.git`
- Latest release: `v0.1.1`
- Marketplace range: `^0.1.0`

The existing range includes `v0.1.1`, so the marketplace entry itself does not need a source change.

## Plugin checks

- 6 tests passed
- TypeScript passed with `--noEmit`
- `bb plugin build` passed
- SDK compatibility check passed against `0.4.15`
- Production dependency audit reported no vulnerabilities

## Marketplace checks

- `npm run build` passed
- `npm run check` passed against the public `v0.1.1` release

## Security and permissions

The plugin uses no external service or credentials. Its host worker invokes read-only Git commands in the thread environment and does not checkout, reset, merge, rebase, or otherwise modify repositories.
