### PR TITLE
Add plugin entry: sql

### DIFF
--- a/entries/sql.json
+++ b/entries/sql.json
@@ -1,0 +1,25 @@
+{
+  "id": "sql",
+  "displayName": "SQL",
+  "description": "Browse Postgres schemas and run read-only SQL from a bb panel or agent tools; write support is planned for 0.5.",
+  "icon": "Database",
+  "tags": [
+    "sql",
+    "postgres",
+    "database",
+    "developer-tools",
+    "query",
+    "read-only"
+  ],
+  "author": {
+    "name": "yazydzhi",
+    "github": "yazydzhi",
+    "url": "https://github.com/yazydzhi"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/yazydzhi/bb-plugin-sql.git",
+      "range": "^0.2.0"
+    }
+  }
+}


### PR DESCRIPTION
## Plugin

SQL — browse Postgres schemas and run read-only SQL from a bb panel or agent tools (`sql_query`, `sql_list_connections`). Writes are deferred until plugin 0.5.

## Source

- Repository: https://github.com/yazydzhi/bb-plugin-sql
- Marketplace range: `^0.2.0`
- Release tag: `v0.2.0` (annotated)

## Checks

- Plugin: `bb plugin build`, TypeScript `tsc --noEmit`
- Marketplace: `npm run build`, `npm run check` (liveness)

## Security / trust notes

- Full-trust bb plugin; stores connection passwords in plugin-private SQLite (`data.db`)
- Queries run under `BEGIN READ ONLY` until 0.5
- No outbound network beyond the configured Postgres hosts
