### PR TITLE
Bump agent-checklists range to ^0.2.0

### DIFF
--- a/entries/agent-checklists.json
+++ b/entries/agent-checklists.json
@@ -3,7 +3,13 @@
   "displayName": "Checklists",
   "description": "Keeps a persisted set of agent-owned steps attached to each BB thread and continues incomplete work automatically.",
   "icon": "ClipboardCheck",
-  "tags": ["agent-tools", "checklists", "threads", "automation", "productivity"],
+  "tags": [
+    "agent-tools",
+    "checklists",
+    "threads",
+    "automation",
+    "productivity"
+  ],
   "author": {
     "name": "Patrick Lee",
     "github": "patleeman",
@@ -13,7 +19,7 @@
     "git": {
       "url": "https://github.com/patleeman/bb-plugins.git",
       "subdir": "packages/bb-plugin-agent-checklists",
-      "range": "^0.1.0",
+      "range": "^0.2.0",
       "tagPrefix": "agent-checklists/"
     }
   }


### PR DESCRIPTION
## Summary
- Bumps the `agent-checklists` source range from `^0.1.0` to `^0.2.0` so the catalog picks up the new 0.2.0 release (caret ranges for 0.x cap at the next minor, so `^0.1.0` no longer matches).

## Release notes (agent-checklists v0.2.0)
- Tool registrations migrate from the removed `experimental_statusLabels` field to `presentation.label` (SDK grammar v3).
- Engines raised to `bb >=0.39`, `bbPluginSdk >=0.4.16`; dev SDK pinned to 0.4.21.
- Vendored SDK type stubs dropped in favor of importing `@get-bb/plugin-sdk` directly.

Tagged at https://github.com/patleeman/bb-plugins/releases/tag/agent-checklists/v0.2.0

`npm run build` and `npm run check` pass locally (82 entries).