### PR TITLE
Add plugin entry: thread-inbox

### DIFF
--- a/entries/thread-inbox.json
+++ b/entries/thread-inbox.json
@@ -1,0 +1,18 @@
+{
+  "id": "thread-inbox",
+  "displayName": "Thread Inbox (w/ Children)",
+  "description": "Replaces the BB thread list with a stable, reorderable inbox that nests child threads and adds parking and bulk actions.",
+  "icon": "PanelLeft",
+  "tags": ["interface", "sidebar", "threads", "inbox", "productivity"],
+  "author": {
+    "name": "WYEZ",
+    "github": "wy3z",
+    "url": "https://github.com/wy3z"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/wy3z/bb-plugin-thread-inbox.git",
+      "range": "^0.2.1"
+    }
+  }
+}


### PR DESCRIPTION
## What it does

Adds Thread Inbox (w/ Children), an evolution of the marketplace's existing T3 Sidebar plugin. It replaces BB's thread list with persistent ordering, nested child threads, parking controls, Git metadata, and bulk actions.

## Source release

- Git: https://github.com/wy3z/bb-plugin-thread-inbox.git
- Release: `v0.2.1`
- Marketplace range: `^0.2.1`

## Validation

- Plugin typecheck passed
- Plugin tests passed: 108 tests across 7 files
- Plugin build passed
- Marketplace build passed
- Marketplace source/liveness check passed

## Security and services

The plugin uses its BB-provided SQLite database for lifecycle and ordering state. It does not require credentials or external services.
