### PR TITLE
Add plugin entry: stale-resume

### DIFF
--- a/entries/stale-resume.json
+++ b/entries/stale-resume.json
@@ -1,0 +1,17 @@
+{
+  "id": "stale-resume",
+  "displayName": "Stale Resume",
+  "description": "Catches threads whose Claude session no longer exists after a working-directory change, reports the incident to the parent thread, and recovers the thread onto a fresh session on one command.",
+  "icon": "LifeBuoy",
+  "tags": ["claude-code", "threads", "recovery", "diagnostics", "reliability"],
+  "author": {
+    "name": "Yegor Korobeynikov",
+    "github": "yegor-korobeynikov"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/yegor-korobeynikov/bb-plugin-stale-resume.git",
+      "range": "^1.0.0"
+    }
+  }
+}


### PR DESCRIPTION
## What it does

Catches the failure where a thread's Claude Code session no longer exists
after a working-directory change. On `thread.failed`, it reads the thread's
event log and, if the newest turn died on a stale-resume error, records the
incident, logs it, and notifies the thread's parent. Recovery is a manual,
explicit command (`bb stale-resume recover <thread-id>`) that forks the
thread onto a fresh session — never automatic, by design.

Commands: `bb stale-resume status`, `bb stale-resume check <thread-id>`,
`bb stale-resume recover <thread-id>`.

## Source release

- Repository: https://github.com/yegor-korobeynikov/bb-plugin-stale-resume
- Release: `v1.0.0` (git range `^1.0.0`)

## Plugin checks that succeeded

- `npm install` — clean
- `npm test` (vitest) — 21/21 passing
- `npm run typecheck` (tsc --noEmit) — clean

## Marketplace checks that succeeded

- `npm ci --ignore-scripts` — clean
- `npm run build` — built `dist/marketplace.json` with 83 entries
- `npm run check` (liveness) — resolved the `^1.0.0` git range against the
  live repository successfully

## Permissions / external services

No external services. The plugin reads bb's own thread event log and posts
to the parent thread; recovery uses bb's existing fork primitive
(`workspace: "reuse"`). No network calls outside the bb host.
