### PR TITLE
Add plugin entry: task-router

### DIFF
--- a/entries/task-router.json
+++ b/entries/task-router.json
@@ -1,0 +1,23 @@
+{
+  "id": "task-router",
+  "displayName": "Task Router",
+  "description": "Notices when a composer draft belongs to a different project than the one selected, and offers to open the thread there with one click, via deterministic name/path matching against the workspace's git repositories.",
+  "icon": "Split",
+  "tags": [
+    "productivity",
+    "workspace",
+    "composer",
+    "projects",
+    "automation"
+  ],
+  "author": {
+    "name": "Yegor Korobeynikov",
+    "github": "yegor-korobeynikov"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/yegor-korobeynikov/bb-plugin-task-router.git",
+      "range": "^1.0.0"
+    }
+  }
+}


### PR DESCRIPTION
## What the plugin does

Task Router notices when a composer draft belongs to a different project than
the one currently selected, and offers to open a new thread there with one
click. Matching is fully deterministic (name/path against the workspace's git
repositories, no model call) and stays silent whenever it isn't confident.

## Source release

- Repository: https://github.com/yegor-korobeynikov/bb-plugin-task-router
- Release: `v1.0.0` (git tag, root of repo)
- Marketplace source: `git` with `range: "^1.0.0"`

## Plugin checks that succeeded

- `npm install`
- `npm test` (18/18 passing)
- `npm run typecheck` (clean)
- `bb plugin build` (produces `dist/server.js`, `dist/app.js`, metadata)

## Marketplace checks that succeeded

- `npm ci --ignore-scripts`
- `npm run build` (composed `dist/marketplace.json` with 83 entries, including this one)
- `npm run check` (liveness check against the live git tag passed)

## Permissions / external services

No external services. The plugin reads local git config/host directory
listings via the bb SDK (`bb.sdk.hosts.*`) to build a workspace census, and
registers/spawns bb projects/threads (`bb.sdk.projects.*`, `bb.sdk.threads.*`)
only when the user clicks the suggestion. No network calls, no model calls.
