### PR TITLE
Add plugin entry: attach-folder

### DIFF
--- a/entries/attach-folder.json
+++ b/entries/attach-folder.json
@@ -1,0 +1,24 @@
+{
+  "id": "attach-folder",
+  "displayName": "Attach Folder",
+  "description": "Adds an Attach Folder row to the bb composer's + menu; picking a folder sends its file manifest and contents to the agent as context, with configurable file-count and size limits.",
+  "icon": "Folder",
+  "tags": [
+    "composer",
+    "context",
+    "attachments",
+    "folder",
+    "files"
+  ],
+  "author": {
+    "name": "Yegor Korobeynikov",
+    "github": "yegor-korobeynikov",
+    "url": "https://github.com/yegor-korobeynikov"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/yegor-korobeynikov/bb-plugin-attach-folder.git",
+      "range": "^1.0.0"
+    }
+  }
+}


### PR DESCRIPTION
## What the plugin does

Adds an **Attach Folder** row to the bb composer's `+` menu. Picking a folder
inserts a mention pill; when the message is sent, the pill resolves to
agent-only context containing the folder's file manifest and the text of
every file that fits the configured budget (`maxFiles`, `maxFileBytes`,
`maxTotalBytes`). Excluded files are listed with their exclusion reason
instead of being dropped silently.

## Source release

- Repository: https://github.com/yegor-korobeynikov/bb-plugin-attach-folder
- License: MIT
- Selected range: `^1.0.0`, resolved against tag `v1.0.0`

## Plugin checks that succeeded

- `npm install`
- `npm test` — 8/8 passing
- `npm run typecheck` — clean

## Marketplace checks that succeeded

- `npm ci --ignore-scripts`
- `npm run build` — validates schema and composes `dist/marketplace.json` (83 entries)
- `npm run check` — liveness check against the published git tag

## Permissions / external services

None. The plugin reads files from folders the user explicitly picks in the
composer and sends their contents to the agent as context; it does not call
any external service.
