### PR TITLE
Move Taskboard and Usage Tracker to Git releases

### DIFF
--- a/entries/taskboard.json
+++ b/entries/taskboard.json
@@ -19,9 +19,11 @@
     "url": "https://github.com/MateoCerquetella"
   },
   "source": {
-    "npm": {
-      "package": "bb-plugin-taskboard",
-      "range": "^0.1.2"
+    "git": {
+      "url": "https://github.com/MateoCerquetella/bb-plugins.git",
+      "subdir": "plugins/taskboard",
+      "range": "^0.3.0",
+      "tagPrefix": "taskboard/"
     }
   }
 }

--- a/entries/usage-tracker.json
+++ b/entries/usage-tracker.json
@@ -16,9 +16,11 @@
     "url": "https://github.com/MateoCerquetella"
   },
   "source": {
-    "npm": {
-      "package": "bb-plugin-usage-tracker",
-      "range": "^0.1.1"
+    "git": {
+      "url": "https://github.com/MateoCerquetella/bb-plugins.git",
+      "subdir": "plugins/usage-tracker",
+      "range": "^0.1.2",
+      "tagPrefix": "usage-tracker/"
     }
   }
 }


### PR DESCRIPTION
## What changed

- Moves Taskboard's marketplace source from npm to the public monorepo at
  `plugins/taskboard`, tracking `^0.3.0` through the `taskboard/` tag prefix.
- Moves Usage Tracker's marketplace source from npm to the same repository at
  `plugins/usage-tracker`, tracking `^0.1.2` through the `usage-tracker/` tag
  prefix.
- Keeps both listing identities, descriptions, authorship, engine ranges, and
  icons unchanged.

## Public releases

- `taskboard/v0.3.1`
- `usage-tracker/v0.1.2`

Both annotated tags resolve to reviewed source commit
`ce9a73401f7bd448f347f6dc6b9d7ae81565df6e` in
`MateoCerquetella/bb-plugins`.

## Checks

- Plugin root checks pass: Taskboard 89 tests plus build metadata; Usage Tracker
  13 tests plus production build.
- Marketplace `npm run build` and `npm run check` pass against both public Git
  sources.
- Both plugin manifests are private and contain no npm publication contract.

No external service permissions or credentials are introduced. The plugins are
full-trust BB plugins installed from the reviewed Git release source.
