### PR TITLE
Add plugin entry: md-comments

### DIFF
--- a/entries/md-comments.json
+++ b/entries/md-comments.json
@@ -1,0 +1,17 @@
+{
+  "id": "md-comments",
+  "displayName": "Md Comments",
+  "description": "Inline comments on markdown files opened in the side panel, anchored to quoted text instead of line numbers, sent to the agent as one batch message.",
+  "icon": "MessageSquare",
+  "tags": ["markdown", "comments", "review", "agent-tools", "productivity"],
+  "author": {
+    "name": "Yegor Korobeynikov",
+    "github": "yegor-korobeynikov"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/yegor-korobeynikov/bb-plugin-md-comments.git",
+      "range": "^1.0.0"
+    }
+  }
+}


### PR DESCRIPTION
## What the plugin does

Adds inline commenting to markdown files opened in the BB side panel: select a
line, phrase, or word in the rendered document and leave a comment against
that exact passage. Comments are anchored to quoted text (not line numbers),
so they follow their passage across edits instead of drifting to the wrong
paragraph. A single button drops the whole unsent batch into the thread
composer as one structured message for the agent, and the agent can reply
inside each comment's own thread (`md_comments_list` / `md_comments_reply` /
`md_comments_reanchor` RPC tools).

## Source release

- Repository: https://github.com/yegor-korobeynikov/bb-plugin-md-comments
- Tag: `v1.0.0`
- Marketplace source: `git` range `^1.0.0` (repository root)

## Plugin checks

- `npm install` — clean install, zero private dependencies
- `npx vitest run` — 25/25 tests passing
- `npx tsc --noEmit` — no type errors
- `bb plugin build` — builds `dist/` successfully

## Marketplace checks

- `npm ci --ignore-scripts && npm run build` — entry validates against the schema, `dist/marketplace.json` built with 83 entries
- `npm run check` — release-source liveness check passes

## Notes for reviewers

- No external services, network calls, or elevated permissions beyond the plugin SDK's normal file/RPC surface.
- Icon uses the host icon name `MessageSquare` (no vendored icon file) — the plugin has no bespoke artwork of its own.
