### PR TITLE
Add plugin entry: tasks-kv

### DIFF
--- a/entries/tasks-kv.json
+++ b/entries/tasks-kv.json
@@ -1,7 +1,7 @@
 {
   "id": "tasks-kv",
   "displayName": "Tasks (KV)",
-  "description": "Plans and tracks work in BB with task dependencies, boards, agent delegation, and linked worker threads.",
+  "description": "Extends BB task planning with force-directed dependency graphs, transitive blocker views, boards, agent delegation, and linked worker threads.",
   "icon": {
     "url": "./icons/tasks-kv-c0dc7351.svg"
   },

--- a/entries/tasks-kv.json
+++ b/entries/tasks-kv.json
@@ -1,0 +1,26 @@
+{
+  "id": "tasks-kv",
+  "displayName": "Tasks (KV)",
+  "description": "Plans and tracks work in BB with task dependencies, boards, agent delegation, and linked worker threads.",
+  "icon": {
+    "url": "./icons/tasks-kv-c0dc7351.svg"
+  },
+  "tags": [
+    "tasks",
+    "project-management",
+    "dependencies",
+    "boards",
+    "agents",
+    "delegation"
+  ],
+  "author": {
+    "name": "Kavii Suri",
+    "github": "KaviiSuri"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/KaviiSuri/bb-plugin-tasks.git",
+      "range": "^0.1.2"
+    }
+  }
+}

--- a/icons/tasks-kv-c0dc7351.svg
+++ b/icons/tasks-kv-c0dc7351.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect x="4" y="4" width="24" height="24" rx="6" stroke="#18181b" stroke-width="2"/>
+  <path d="m9 11 2 2 3-4M16 11h7M9 19l2 2 3-4M16 19h7" stroke="#18181b" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## What it does

Tasks (KV) plans and tracks work in BB with task dependencies, list and board views, agent delegation, linked worker threads, and a force-directed relationship graph.

## Source

- Repository: https://github.com/KaviiSuri/bb-plugin-tasks
- Git range: `^0.1.2`
- Reviewed release: [`v0.1.2`](https://github.com/KaviiSuri/bb-plugin-tasks/releases/tag/v0.1.2)

## Validation

Plugin release checks:
- 38 graph and route tests passed
- BB plugin build passed
- release artifact identity/version verification passed for `tasks-kv@0.1.2`
- production dependency audit passed with 0 vulnerabilities

Marketplace checks:
- `npm run build` passed and composed the manifest with this entry
- the vendored SVG is 304 bytes and its filename contains its SHA-256 prefix
- the Git source exposes annotated semver tag `v0.1.2`
- liveness validation passed with the two currently unpublished pre-existing npm entries (`taskboard` and `usage-tracker`) excluded; the unmodified full check is presently blocked by those unrelated entries

## Security and services

The plugin requires no external service or user secret. Task data stays in BB's plugin data store. It exposes BB agent tools for task operations and can delegate tasks to BB threads when the user requests it.
