### PR TITLE
Publish marketplace/v2 beside v1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
+      # Full history: v2 derives each listing's publication dates from this
+      # repository's commits, and a shallow checkout would date every entry
+      # from the same single commit. The build refuses to run shallow.
       - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
       - uses: actions/setup-node@v4
         with: { node-version: 20 }
       - run: npm ci
@@ -24,11 +28,21 @@ jobs:
             npx wrangler@4 r2 object put "bb-marketplace/icons/$(basename "$icon")" \
               --file "$icon" --remote
           done
-      - name: Upload manifest
+      # v1 sits at the bucket root because released clients already fetch that
+      # key; v2 lives under v2/ so discovery assets can evolve without it.
+      - name: Upload v1 manifest
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           npx wrangler@4 r2 object put "bb-marketplace/marketplace.json" \
             --file dist/marketplace.json \
+            --content-type application/json --remote
+      - name: Upload v2 manifest
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          npx wrangler@4 r2 object put "bb-marketplace/v2/marketplace.json" \
+            --file dist/v2/marketplace.json \
             --content-type application/json --remote

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,7 +5,10 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
+      # Full history so the v2 date derivation runs the same way it will on
+      # publish; a shallow checkout fails the build rather than dating wrong.
       - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
       - uses: actions/setup-node@v4
         with: { node-version: 20 }
       - run: npm ci

--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
 # BB Community plugin marketplace
 
 The registry for the BB Community plugin marketplace, which BB registers
-under the reserved name `bb-community`. Merges to `main`
-publish `https://getbb.app/marketplace/v1/marketplace.json`, which every BB
-installation refreshes.
+under the reserved name `bb-community`. Merges to `main` publish two
+manifests, which every BB installation refreshes:
+
+- `marketplace/v1/marketplace.json` — the frozen contract every released BB
+  reads. Its field set never grows.
+- `marketplace/v2/marketplace.json` — the discovery catalog. Same listings,
+  plus the category each one files under and the dates it was published and
+  last changed. Newer BB reads v2 and falls back to v1.
+
+One entry file feeds both. You write the v2 shape; the build projects v1 out
+of it by dropping the fields v1 does not have.
 
 ## Layout
 
@@ -11,11 +19,15 @@ installation refreshes.
   filename must equal the entry `id`. One file per plugin keeps submission
   pull requests conflict-free.
 - `icons/` — optional icon files referenced relatively from entries.
-- `marketplace.base.json` — marketplace identity (name, display name).
-- `schema/marketplace.schema.json` — the entry contract. Canonical URL:
+- `marketplace.base.json` — marketplace identity (name, display name), and
+  optionally `newAndNotable`.
+- `schema/marketplace.schema.json` — the v1 contract. Canonical URL:
   <https://getbb.app/schemas/marketplace.schema.json>.
+- `schema/marketplace-v2.schema.json` — the v2 contract, and the schema each
+  entry file is validated against. Canonical URL:
+  <https://getbb.app/schemas/marketplace-v2.schema.json>.
 - `scripts/build.mjs` — validates everything and composes
-  `dist/marketplace.json` deterministically.
+  `dist/marketplace.json` and `dist/v2/marketplace.json` deterministically.
 - `scripts/build-stats.mjs` — composes `dist/stats.json`, the install-count
   sidecar, from BB's `plugin_installed` telemetry.
 
@@ -25,7 +37,10 @@ installation refreshes.
 2. Add `entries/<your-plugin-id>.json`. The `id` must match the plugin id
    that your plugin package manifest derives. Point `source` at your public
    git repository (with an optional `subdir` for multi-plugin repositories)
-   or your npm package.
+   or your npm package. Set `category` to the one your plugin belongs in —
+   the list is closed and there is no "Other", so pick the closest fit and a
+   reviewer will correct it if it lands wrong. You may add up to six
+   `screenshots`.
 3. Open a pull request. CI validates the entry; a maintainer reviews the
    plugin itself, including its source and behavior.
 
@@ -38,6 +53,28 @@ The account that opens the listing pull request is recorded as the owner in
 BB installs nothing automatically: a catalog refresh only surfaces
 `bb plugin outdated`, and applying an update is a manual, staged,
 rollback-protected action.
+
+## Categories and dates
+
+`category` is the only field a submitter writes that v1 does not have. It is
+one of BB's sixteen canonical categories, listed as an enum in
+`schema/marketplace-v2.schema.json`; the closed list is what lets the store
+show real shelves instead of one undifferentiated pile.
+
+`publishedAt` and `updatedAt` are **not** author-supplied — the build derives
+them from this repository's own history. An entry file's first commit is when
+that listing went live, its latest commit is when it last changed. Nobody can
+backdate a listing onto the front of the "Recently added" shelf, and there is
+no date to keep in sync by hand.
+
+That derivation needs full git history. Both workflows check out with
+`fetch-depth: 0`, and the build refuses to run in a shallow clone rather than
+publish 82 listings that all claim the same date.
+
+`newAndNotable` in `marketplace.base.json` is the shelf BB renders as "New &
+notable", most notable first. Set it to curate that shelf by hand; leave it
+unset and the build fills it with the six newest listings, so it stays current
+on its own.
 
 ## Install counts
 
@@ -85,6 +122,6 @@ POSTHOG_API_KEY=… POSTHOG_PROJECT_ID=… node scripts/build-stats.mjs --print
 
 ```sh
 npm ci
-npm run build   # validate + compose dist/marketplace.json
+npm run build   # validate + compose dist/marketplace.json and dist/v2/marketplace.json
 npm run check   # also verify sources exist (git ls-remote / npm view)
 ```

--- a/entries/advisor.json
+++ b/entries/advisor.json
@@ -11,6 +11,7 @@
     "quality",
     "reviews"
   ],
+  "category": "agent-tools",
   "author": {
     "name": "Salem Sayed Abdel Gawad",
     "github": "salemsayed",

--- a/entries/agent-checklists.json
+++ b/entries/agent-checklists.json
@@ -4,6 +4,7 @@
   "description": "Keeps a persisted set of agent-owned steps attached to each BB thread and continues incomplete work automatically.",
   "icon": "ClipboardCheck",
   "tags": ["agent-tools", "checklists", "threads", "automation", "productivity"],
+  "category": "task-tracking",
   "author": {
     "name": "Patrick Lee",
     "github": "patleeman",

--- a/entries/agent-proxy.json
+++ b/entries/agent-proxy.json
@@ -6,6 +6,7 @@
     "url": "./icons/agent-proxy-b3dff2b6.svg"
   },
   "tags": ["proxy", "providers", "oauth", "agents", "developer-tools"],
+  "category": "agents-and-providers",
   "author": {
     "name": "Scott Sunarto",
     "github": "smsunarto",

--- a/entries/agentation-mentions.json
+++ b/entries/agentation-mentions.json
@@ -13,6 +13,7 @@
     "queue",
     "visual-feedback"
   ],
+  "category": "plugin-development",
   "author": {
     "name": "Phosphor",
     "github": "its-rosetta",

--- a/entries/agentation.json
+++ b/entries/agentation.json
@@ -4,6 +4,7 @@
   "description": "Adds an annotation toolbar to bb: point at any part of the interface, including other plugins' surfaces, and send the marked-up elements to a thread as structured feedback agents can read, reply to, and resolve.",
   "icon": { "url": "./icons/agentation-2c7e22e8.svg" },
   "tags": ["annotations", "visual-feedback", "review", "interface", "agents", "toolbar"],
+  "category": "plugin-development",
   "author": {
     "name": "Scott Sunarto",
     "github": "smsunarto",

--- a/entries/amp.json
+++ b/entries/amp.json
@@ -6,6 +6,7 @@
     "url": "./icons/amp-84180045.svg"
   },
   "tags": ["amp", "provider", "agents", "acp", "sandbox"],
+  "category": "agents-and-providers",
   "author": {
     "name": "Scott Sunarto",
     "github": "smsunarto",

--- a/entries/arc-switcher.json
+++ b/entries/arc-switcher.json
@@ -4,6 +4,7 @@
   "description": "Cycles through your seven most recently opened BB chats with an Arc-style Command-D switcher.",
   "icon": "Layers",
   "tags": ["interface", "keyboard-shortcuts", "navigation", "threads"],
+  "category": "thread-lists-and-navigation",
   "author": {
     "name": "Elliott McNary",
     "github": "bighitbiker3"

--- a/entries/attention.json
+++ b/entries/attention.json
@@ -9,6 +9,7 @@
     "attention",
     "notifications"
   ],
+  "category": "notifications-and-attention",
   "author": {
     "name": "Shane Logsdon",
     "github": "slogsdon",

--- a/entries/audio-preview.json
+++ b/entries/audio-preview.json
@@ -12,6 +12,7 @@
     "interface",
     "m4a"
   ],
+  "category": "files-and-viewers",
   "author": {
     "name": "Braedon Saunders",
     "github": "braedonsaunders",

--- a/entries/auto-archive.json
+++ b/entries/auto-archive.json
@@ -9,6 +9,7 @@
     "automation",
     "cleanup"
   ],
+  "category": "automation",
   "author": {
     "name": "Shane Logsdon",
     "github": "slogsdon",

--- a/entries/autorouter.json
+++ b/entries/autorouter.json
@@ -10,6 +10,7 @@
     "automation",
     "cost-control"
   ],
+  "category": "agents-and-providers",
   "author": {
     "name": "Jacob Miller",
     "github": "jjcm",

--- a/entries/ayu.json
+++ b/entries/ayu.json
@@ -13,6 +13,7 @@
     "interface",
     "ayu"
   ],
+  "category": "themes-and-appearance",
   "author": {
     "name": "Vedran Burojević",
     "github": "vburojevic"

--- a/entries/bb-better-latex.json
+++ b/entries/bb-better-latex.json
@@ -6,6 +6,7 @@
     "url": "./icons/bb-better-latex-8274bdfa.svg"
   },
   "tags": ["interface", "latex", "math", "markdown"],
+  "category": "thread-messages-and-timelines",
   "author": {
     "name": "Zhen Huang",
     "github": "ZhenHuangLab",

--- a/entries/bb-rpiv-todo-renderer.json
+++ b/entries/bb-rpiv-todo-renderer.json
@@ -6,6 +6,7 @@
     "url": "./icons/bb-rpiv-todo-renderer-3665901c.svg"
   },
   "tags": ["interface", "todo", "composer", "pi"],
+  "category": "thread-messages-and-timelines",
   "author": {
     "name": "Zhen Huang",
     "github": "ZhenHuangLab",

--- a/entries/bb-sidebar.json
+++ b/entries/bb-sidebar.json
@@ -4,6 +4,7 @@
   "description": "A sidebar inspired by T3 Code that adds manual and automatic thread sorting, collapsible shelves, and bulk actions to bb.",
   "icon": "PanelLeft",
   "tags": ["interface", "sidebar", "threads", "inbox", "productivity"],
+  "category": "thread-lists-and-navigation",
   "author": {
     "name": "Yusuf Akbulut",
     "github": "yusuf8834",

--- a/entries/bb-ui-reference.json
+++ b/entries/bb-ui-reference.json
@@ -6,6 +6,7 @@
     "url": "./icons/bb-ui-reference-cc9d856d.png"
   },
   "tags": ["design-system", "developer-tools", "interface", "themes"],
+  "category": "plugin-development",
   "author": {
     "name": "Phosphor",
     "github": "its-rosetta",

--- a/entries/bots.json
+++ b/entries/bots.json
@@ -14,6 +14,7 @@
     "sidebar",
     "agents"
   ],
+  "category": "agents-and-providers",
   "author": {
     "name": "Prakash Chokalingam",
     "github": "prakashchokalingam",

--- a/entries/callstack.json
+++ b/entries/callstack.json
@@ -13,6 +13,7 @@
     "threads",
     "visualization"
   ],
+  "category": "code-and-reviews",
   "author": {
     "name": "Ethan Greenfeld",
     "github": "ebg1223",

--- a/entries/cascade.json
+++ b/entries/cascade.json
@@ -6,6 +6,7 @@
     "url": "./icons/cascade-7b651515.svg"
   },
   "tags": ["interface", "threads", "workspace"],
+  "category": "thread-lists-and-navigation",
   "author": {
     "name": "Sawyer Hood",
     "github": "SawyerHood"

--- a/entries/chime.json
+++ b/entries/chime.json
@@ -11,6 +11,7 @@
     "sounds",
     "attention"
   ],
+  "category": "notifications-and-attention",
   "author": {
     "name": "Guilherme J. Tramontina",
     "github": "gtramontina",

--- a/entries/context-meter.json
+++ b/entries/context-meter.json
@@ -12,6 +12,7 @@
     "tokens",
     "smart-zone"
   ],
+  "category": "token-usage-and-cost",
   "author": {
     "name": "Roger Serra",
     "github": "Hazihell"

--- a/entries/copy-session-id.json
+++ b/entries/copy-session-id.json
@@ -4,6 +4,7 @@
   "description": "Copy a thread's session ID from its left-sidebar context menu.",
   "icon": "Copy",
   "tags": ["clipboard", "threads", "sidebar"],
+  "category": "thread-lists-and-navigation",
   "author": {
     "name": "Patrick Lee",
     "github": "patleeman",

--- a/entries/dependabot.json
+++ b/entries/dependabot.json
@@ -6,6 +6,7 @@
     "url": "./icons/dependabot-5b70e0d3.svg"
   },
   "tags": ["dependabot", "github", "security", "dependencies", "alerts"],
+  "category": "code-and-reviews",
   "author": {
     "name": "Nicolas Charpentier",
     "github": "charpeni",

--- a/entries/disk-usage.json
+++ b/entries/disk-usage.json
@@ -6,6 +6,7 @@
     "url": "./icons/disk-usage-fff016e3.svg"
   },
   "tags": ["disk-usage", "storage", "ncdu", "server", "interface"],
+  "category": "machines-and-hosts",
   "author": {
     "name": "Nicolas Charpentier",
     "github": "charpeni",

--- a/entries/dispatch.json
+++ b/entries/dispatch.json
@@ -12,6 +12,7 @@
     "task-routing",
     "prompt-expansion"
   ],
+  "category": "composer-and-prompts",
   "author": {
     "name": "Shane Logsdon",
     "github": "slogsdon",

--- a/entries/emoji-react.json
+++ b/entries/emoji-react.json
@@ -6,6 +6,7 @@
     "url": "./icons/emoji-react-61419fba.svg"
   },
   "tags": ["emoji", "reactions", "chat", "interface"],
+  "category": "thread-messages-and-timelines",
   "author": {
     "name": "Patrick Lee",
     "github": "patleeman",

--- a/entries/file-manager.json
+++ b/entries/file-manager.json
@@ -11,6 +11,7 @@
     "host-access",
     "interface"
   ],
+  "category": "machines-and-hosts",
   "author": {
     "name": "Foma",
     "github": "xMinor-1",

--- a/entries/floating-terminal.json
+++ b/entries/floating-terminal.json
@@ -14,6 +14,7 @@
     "tabs",
     "multi-machine"
   ],
+  "category": "machines-and-hosts",
   "author": {
     "name": "Vedran Burojevic",
     "github": "vburojevic"

--- a/entries/fonts.json
+++ b/entries/fonts.json
@@ -12,6 +12,7 @@
     "customization",
     "interface"
   ],
+  "category": "themes-and-appearance",
   "author": {
     "name": "Guilherme J. Tramontina",
     "github": "gtramontina",

--- a/entries/gh-stack.json
+++ b/entries/gh-stack.json
@@ -6,6 +6,7 @@
     "url": "./icons/gh-stack-638265b0.svg"
   },
   "tags": ["github", "pull-requests", "stacked-prs", "git", "developer-tools"],
+  "category": "code-and-reviews",
   "author": {
     "name": "Scott Sunarto",
     "github": "smsunarto",

--- a/entries/git-history.json
+++ b/entries/git-history.json
@@ -4,6 +4,7 @@
   "description": "Shows the complete Git history of a project as a compact commit graph with changed files and per-file diffs.",
   "icon": "FolderGit",
   "tags": ["git", "history", "version-control", "diffs", "interface"],
+  "category": "code-and-reviews",
   "author": {
     "name": "Yusuf Akbulut",
     "github": "yusuf8834",

--- a/entries/gitlab.json
+++ b/entries/gitlab.json
@@ -6,6 +6,7 @@
     "url": "./icons/gitlab-37bd255a.svg"
   },
   "tags": ["gitlab", "issues", "merge-requests", "code-review", "interface"],
+  "category": "code-and-reviews",
   "author": {
     "name": "Marius Nouchet",
     "github": "suiramdev",

--- a/entries/global-workflows.json
+++ b/entries/global-workflows.json
@@ -8,6 +8,7 @@
     "automation",
     "orchestration"
   ],
+  "category": "automation",
   "author": {
     "name": "Shane Logsdon",
     "github": "slogsdon",

--- a/entries/gtd-sidebar.json
+++ b/entries/gtd-sidebar.json
@@ -6,6 +6,7 @@
     "url": "./icons/gtd-sidebar-0a2df40e.svg"
   },
   "tags": ["interface", "sidebar", "threads", "inbox", "productivity"],
+  "category": "thread-lists-and-navigation",
   "author": {
     "name": "Scott Sunarto",
     "github": "smsunarto",

--- a/entries/handoff.json
+++ b/entries/handoff.json
@@ -16,6 +16,7 @@
     "opencode",
     "agent-tools"
   ],
+  "category": "agents-and-providers",
   "author": {
     "name": "Vedran Burojevic",
     "github": "vburojevic",

--- a/entries/headroom.json
+++ b/entries/headroom.json
@@ -11,6 +11,7 @@
     "monitoring",
     "agent-interaction"
   ],
+  "category": "token-usage-and-cost",
   "author": {
     "name": "prismatic7",
     "github": "prismatic7"

--- a/entries/image-preview.json
+++ b/entries/image-preview.json
@@ -11,6 +11,7 @@
     "gallery",
     "interface"
   ],
+  "category": "thread-messages-and-timelines",
   "author": {
     "name": "Dwite",
     "github": "Dwite",

--- a/entries/lanes.json
+++ b/entries/lanes.json
@@ -13,6 +13,7 @@
     "openrouter",
     "opencode"
   ],
+  "category": "token-usage-and-cost",
   "author": {
     "name": "Shane Logsdon",
     "github": "slogsdon",

--- a/entries/message-timestamps.json
+++ b/entries/message-timestamps.json
@@ -4,6 +4,7 @@
   "description": "Shows the time you sent each message next to your bubbles in BB chat windows.",
   "icon": "Clock",
   "tags": ["interface", "chat", "messages", "threads"],
+  "category": "thread-messages-and-timelines",
   "author": {
     "name": "Elliott McNary",
     "github": "bighitbiker3"

--- a/entries/monaco.json
+++ b/entries/monaco.json
@@ -11,6 +11,7 @@
     "interface",
     "developer-tools"
   ],
+  "category": "files-and-viewers",
   "author": {
     "name": "Andrew Chan",
     "github": "andrewkchan",

--- a/entries/monokai.json
+++ b/entries/monokai.json
@@ -6,6 +6,7 @@
     "url": "./icons/monokai-ae0f7cce.svg"
   },
   "tags": ["theme", "dark", "monokai", "terminal", "interface"],
+  "category": "themes-and-appearance",
   "author": {
     "name": "Scott Sunarto",
     "github": "smsunarto",

--- a/entries/noema.json
+++ b/entries/noema.json
@@ -11,6 +11,7 @@
     "federation",
     "agent-interaction"
   ],
+  "category": "memory-and-context",
   "author": {
     "name": "prismatic7",
     "github": "prismatic7"

--- a/entries/noisegate.json
+++ b/entries/noisegate.json
@@ -11,6 +11,7 @@
     "filtering",
     "agent-interaction"
   ],
+  "category": "agent-tools",
   "author": {
     "name": "prismatic7",
     "github": "prismatic7"

--- a/entries/notify.json
+++ b/entries/notify.json
@@ -6,6 +6,7 @@
     "url": "./icons/notify-c5803165.svg"
   },
   "tags": ["notifications", "macos", "threads", "agent-tools"],
+  "category": "notifications-and-attention",
   "author": {
     "name": "Scott Sunarto",
     "github": "smsunarto",

--- a/entries/ntfy.json
+++ b/entries/ntfy.json
@@ -11,6 +11,7 @@
     "push",
     "mobile"
   ],
+  "category": "notifications-and-attention",
   "author": {
     "name": "Shane Logsdon",
     "github": "slogsdon",

--- a/entries/pdf-viewer.json
+++ b/entries/pdf-viewer.json
@@ -14,6 +14,7 @@
     "reader",
     "interface"
   ],
+  "category": "files-and-viewers",
   "author": {
     "name": "Foma",
     "github": "xMinor-1",

--- a/entries/perspectives.json
+++ b/entries/perspectives.json
@@ -12,6 +12,7 @@
     "orchestration",
     "research"
   ],
+  "category": "agent-tools",
   "author": {
     "name": "Phosphor",
     "github": "its-rosetta",

--- a/entries/pets.json
+++ b/entries/pets.json
@@ -6,6 +6,7 @@
     "url": "./icons/pets-88a81ec9.svg"
   },
   "tags": ["companion", "interface", "pixel-art", "threads", "ai-art"],
+  "category": "themes-and-appearance",
   "author": {
     "name": "Vedran Burojevic",
     "github": "vburojevic"

--- a/entries/ports.json
+++ b/entries/ports.json
@@ -11,6 +11,7 @@
     "networking",
     "process-management"
   ],
+  "category": "machines-and-hosts",
   "author": {
     "name": "Rama Audra",
     "github": "ramaaudra",

--- a/entries/progressive-skill.json
+++ b/entries/progressive-skill.json
@@ -11,6 +11,7 @@
     "efficiency",
     "agent-interaction"
   ],
+  "category": "memory-and-context",
   "author": {
     "name": "prismatic7",
     "github": "prismatic7"

--- a/entries/project-instructions.json
+++ b/entries/project-instructions.json
@@ -11,6 +11,7 @@
     "monorepo",
     "settings"
   ],
+  "category": "memory-and-context",
   "author": {
     "name": "Roger Serra",
     "github": "Hazihell"

--- a/entries/prompt-enhancer.json
+++ b/entries/prompt-enhancer.json
@@ -12,6 +12,7 @@
     "interface",
     "keyboard-shortcuts"
   ],
+  "category": "composer-and-prompts",
   "author": {
     "name": "Vedran Burojević",
     "github": "vburojevic"

--- a/entries/prompts.json
+++ b/entries/prompts.json
@@ -15,6 +15,7 @@
     "threads",
     "productivity"
   ],
+  "category": "composer-and-prompts",
   "author": {
     "name": "Vedran Burojević",
     "github": "vburojevic",

--- a/entries/provider-authentication.json
+++ b/entries/provider-authentication.json
@@ -10,6 +10,7 @@
     "claude-code",
     "settings"
   ],
+  "category": "agents-and-providers",
   "author": {
     "name": "wjin17",
     "github": "wjin17",

--- a/entries/provider-usage.json
+++ b/entries/provider-usage.json
@@ -16,6 +16,7 @@
     "opencode",
     "sidebar"
   ],
+  "category": "token-usage-and-cost",
   "author": {
     "name": "Braedon Saunders",
     "github": "braedonsaunders",

--- a/entries/rephrase.json
+++ b/entries/rephrase.json
@@ -4,6 +4,7 @@
   "description": "Adds a Re-phrase button to the prompt input that rewrites your draft with an agent and puts the result back in the composer.",
   "icon": "AiContentGenerator01",
   "tags": ["prompt", "composer", "interface", "writing"],
+  "category": "composer-and-prompts",
   "author": {
     "name": "suiramdev",
     "github": "suiramdev"

--- a/entries/repo-watch.json
+++ b/entries/repo-watch.json
@@ -1,1 +1,24 @@
-{"id":"repo-watch","displayName":"Repo Watch","description":"Adds a bb navigation screen that monitors local git repositories, worktrees, and branches, highlighting ones that need attention.","icon":"Zap","tags":["git","repositories","worktrees","monitoring"],"author":{"name":"Shane Logsdon","github":"slogsdon","url":"https://github.com/slogsdon"},"source":{"npm":{"package":"bb-plugin-repo-watch","range":"^0.2.0"}}}
+{
+  "id": "repo-watch",
+  "displayName": "Repo Watch",
+  "description": "Adds a bb navigation screen that monitors local git repositories, worktrees, and branches, highlighting ones that need attention.",
+  "icon": "Zap",
+  "category": "code-and-reviews",
+  "tags": [
+    "git",
+    "repositories",
+    "worktrees",
+    "monitoring"
+  ],
+  "author": {
+    "name": "Shane Logsdon",
+    "github": "slogsdon",
+    "url": "https://github.com/slogsdon"
+  },
+  "source": {
+    "npm": {
+      "package": "bb-plugin-repo-watch",
+      "range": "^0.2.0"
+    }
+  }
+}

--- a/entries/rtk.json
+++ b/entries/rtk.json
@@ -11,6 +11,7 @@
     "shell",
     "filtering"
   ],
+  "category": "agent-tools",
   "author": {
     "name": "prismatic7",
     "github": "prismatic7"

--- a/entries/security-guidance.json
+++ b/entries/security-guidance.json
@@ -11,6 +11,7 @@
     "safety",
     "agent-interaction"
   ],
+  "category": "security",
   "author": {
     "name": "prismatic7",
     "github": "prismatic7"

--- a/entries/server-status.json
+++ b/entries/server-status.json
@@ -14,6 +14,7 @@
     "sidebar",
     "interface"
   ],
+  "category": "machines-and-hosts",
   "author": {
     "name": "Foma",
     "github": "xMinor-1",

--- a/entries/session-notes.json
+++ b/entries/session-notes.json
@@ -11,6 +11,7 @@
     "interface",
     "markdown"
   ],
+  "category": "thread-messages-and-timelines",
   "author": {
     "name": "Pablo Oliva",
     "github": "pablooliva",

--- a/entries/sidebar-filter.json
+++ b/entries/sidebar-filter.json
@@ -1,1 +1,26 @@
-{"id":"sidebar-filter","displayName":"Sidebar Project Filter","description":"Replaces the sidebar thread list with a project-grouped view that hides projects without active threads.","icon":{"url":"./icons/sidebar-filter-610d1d3c.svg"},"tags":["sidebar","threads","interface","workspace"],"author":{"name":"Shane Logsdon","github":"slogsdon","url":"https://github.com/slogsdon"},"source":{"npm":{"package":"bb-plugin-sidebar-filter","range":"^0.2.0"}}}
+{
+  "id": "sidebar-filter",
+  "displayName": "Sidebar Project Filter",
+  "description": "Replaces the sidebar thread list with a project-grouped view that hides projects without active threads.",
+  "icon": {
+    "url": "./icons/sidebar-filter-610d1d3c.svg"
+  },
+  "category": "thread-lists-and-navigation",
+  "tags": [
+    "sidebar",
+    "threads",
+    "interface",
+    "workspace"
+  ],
+  "author": {
+    "name": "Shane Logsdon",
+    "github": "slogsdon",
+    "url": "https://github.com/slogsdon"
+  },
+  "source": {
+    "npm": {
+      "package": "bb-plugin-sidebar-filter",
+      "range": "^0.2.0"
+    }
+  }
+}

--- a/entries/slopcop.json
+++ b/entries/slopcop.json
@@ -10,6 +10,7 @@
     "github",
     "reviews"
   ],
+  "category": "code-and-reviews",
   "author": {
     "name": "Sawyer Hood",
     "github": "SawyerHood"

--- a/entries/sticky-notes.json
+++ b/entries/sticky-notes.json
@@ -11,6 +11,7 @@
     "notes",
     "threads"
   ],
+  "category": "thread-messages-and-timelines",
   "author": {
     "name": "Phosphor",
     "github": "its-rosetta",

--- a/entries/t3sidebar.json
+++ b/entries/t3sidebar.json
@@ -4,6 +4,7 @@
   "description": "Replaces the BB thread list with a stable inbox, snooze controls, and child thread links.",
   "icon": "PanelLeft",
   "tags": ["interface", "sidebar", "threads"],
+  "category": "thread-lists-and-navigation",
   "author": {
     "name": "Sawyer Hood",
     "github": "SawyerHood"

--- a/entries/taskboard.json
+++ b/entries/taskboard.json
@@ -13,6 +13,7 @@
     "linear",
     "jira"
   ],
+  "category": "task-tracking",
   "author": {
     "name": "Mateo Cerquetella",
     "github": "MateoCerquetella",

--- a/entries/theme-toggle.json
+++ b/entries/theme-toggle.json
@@ -13,6 +13,7 @@
     "sidebar",
     "interface"
   ],
+  "category": "themes-and-appearance",
   "author": {
     "name": "Foma",
     "github": "xMinor-1",

--- a/entries/thread-namer.json
+++ b/entries/thread-namer.json
@@ -4,6 +4,7 @@
   "description": "Names threads with an agent when their first turn ends, so the sidebar reads as what you were doing, and re-generates a name on demand from the thread header or the CLI.",
   "icon": "AiContentGenerator01",
   "tags": ["thread", "title", "naming", "sidebar", "agent", "interface"],
+  "category": "thread-lists-and-navigation",
   "author": {
     "name": "Marius Nouchet",
     "github": "suiramdev",

--- a/entries/thread-provider-icons.json
+++ b/entries/thread-provider-icons.json
@@ -12,6 +12,7 @@
     "icons",
     "providers"
   ],
+  "category": "thread-lists-and-navigation",
   "author": {
     "name": "Braedon Saunders",
     "github": "braedonsaunders",

--- a/entries/tinted-threads.json
+++ b/entries/tinted-threads.json
@@ -4,6 +4,7 @@
   "description": "A tinted replacement for bb's sidebar thread list with active and blocked row hues, provider glyphs, git diff badges, and sub-thread nesting.",
   "icon": "PanelLeft",
   "tags": ["interface", "sidebar", "threads"],
+  "category": "thread-lists-and-navigation",
   "author": {
     "name": "Tom McKenzie",
     "github": "grrowl"

--- a/entries/tokenmaxx.json
+++ b/entries/tokenmaxx.json
@@ -13,6 +13,7 @@
     "accounts",
     "developer-tools"
   ],
+  "category": "token-usage-and-cost",
   "author": {
     "name": "Pedro Filho",
     "github": "pedroapfilho",

--- a/entries/tokyo-night.json
+++ b/entries/tokyo-night.json
@@ -6,6 +6,7 @@
     "url": "./icons/tokyo-night-6c795cf1.svg"
   },
   "tags": ["themes", "appearance", "colors", "interface", "tokyo-night"],
+  "category": "themes-and-appearance",
   "author": {
     "name": "Justin Krehel",
     "github": "krehel",

--- a/entries/traces.json
+++ b/entries/traces.json
@@ -12,6 +12,7 @@
     "trajectories",
     "developer-tools"
   ],
+  "category": "plugin-development",
   "author": {
     "name": "Patrick Lee",
     "github": "patleeman",

--- a/entries/ui-tweaks.json
+++ b/entries/ui-tweaks.json
@@ -10,6 +10,7 @@
     "sidebar",
     "workspace"
   ],
+  "category": "themes-and-appearance",
   "author": {
     "name": "WYEZ",
     "github": "wy3z",

--- a/entries/unslop.json
+++ b/entries/unslop.json
@@ -11,6 +11,7 @@
     "writing",
     "agent-interaction"
   ],
+  "category": "agent-tools",
   "author": {
     "name": "prismatic7",
     "github": "prismatic7"

--- a/entries/usage-meter.json
+++ b/entries/usage-meter.json
@@ -14,6 +14,7 @@
     "sidebar",
     "interface"
   ],
+  "category": "token-usage-and-cost",
   "author": {
     "name": "Foma",
     "github": "xMinor-1",

--- a/entries/usage-page.json
+++ b/entries/usage-page.json
@@ -12,6 +12,7 @@
     "codex",
     "pi"
   ],
+  "category": "token-usage-and-cost",
   "author": {
     "name": "Evan",
     "github": "iamEvanYT",

--- a/entries/usage-tracker.json
+++ b/entries/usage-tracker.json
@@ -10,6 +10,7 @@
     "claude-code",
     "sidebar"
   ],
+  "category": "token-usage-and-cost",
   "author": {
     "name": "Mateo Cerquetella",
     "github": "MateoCerquetella",

--- a/entries/usage.json
+++ b/entries/usage.json
@@ -4,6 +4,7 @@
   "description": "Tracks coding-agent token usage and estimated API cost across enrolled machines.",
   "icon": "ChartColumn",
   "tags": ["analytics", "costs", "tokens", "usage"],
+  "category": "token-usage-and-cost",
   "author": {
     "name": "Mayank Bansal",
     "github": "MayankBansal12"

--- a/entries/web-push-notify.json
+++ b/entries/web-push-notify.json
@@ -4,6 +4,7 @@
   "description": "Sends browser notifications when BB agents finish or fail, even while BB is closed.",
   "icon": "Mail",
   "tags": ["agents", "notifications", "web-push"],
+  "category": "notifications-and-attention",
   "author": {
     "name": "Mayank Bansal",
     "github": "MayankBansal12"

--- a/entries/worktree-setup.json
+++ b/entries/worktree-setup.json
@@ -10,6 +10,7 @@
     "setup",
     "automation"
   ],
+  "category": "machines-and-hosts",
   "author": {
     "name": "Kavii Suri",
     "github": "KaviiSuri"

--- a/entries/wterm-terminal-preview.json
+++ b/entries/wterm-terminal-preview.json
@@ -10,6 +10,7 @@
     "file-transfer",
     "ghostty"
   ],
+  "category": "machines-and-hosts",
   "author": {
     "name": "Andrew Kiryushkin",
     "github": "Diffuzmetall",

--- a/schema/marketplace-v2.schema.json
+++ b/schema/marketplace-v2.schema.json
@@ -1,0 +1,304 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://getbb.app/schemas/marketplace-v2.schema.json",
+  "title": "BB plugin marketplace manifest (v2)",
+  "description": "The discovery catalog. Every v1 field means exactly what it means in v1; v2 adds the category each listing files under, optional screenshots, and the publication dates the registry derives from its own git history. Released clients that predate v2 keep reading marketplace/v1, which this manifest never replaces.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "name",
+    "displayName",
+    "newAndNotable",
+    "plugins"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://getbb.app/schemas/marketplace-v2.schema.json"
+    },
+    "schemaVersion": {
+      "const": 2
+    },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*$"
+    },
+    "displayName": {
+      "type": "string",
+      "minLength": 1
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1
+    },
+    "newAndNotable": {
+      "type": "array",
+      "$comment": "Curated shelf, most notable first. Every id must name an entry in plugins.",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9][a-z0-9-]*$"
+      }
+    },
+    "plugins": {
+      "type": "array",
+      "$comment": "Entry ids must also be unique within one manifest.",
+      "items": {
+        "$ref": "#/$defs/entry"
+      },
+      "maxItems": 256
+    }
+  },
+  "$defs": {
+    "entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "displayName",
+        "description",
+        "icon",
+        "category",
+        "author",
+        "source"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "$comment": "The plugin id this entry installs; BB refuses an install whose manifest declares another id.",
+          "pattern": "^[a-z0-9][a-z0-9-]*$"
+        },
+        "displayName": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "icon": {
+          "oneOf": [
+            {
+              "type": "string",
+              "$comment": "A host icon name such as ZoomIn.",
+              "pattern": "^[A-Za-z][A-Za-z0-9]*$"
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "url"
+              ],
+              "properties": {
+                "url": {
+                  "type": "string",
+                  "$comment": "Absolute https URL, or a URL relative to this manifest. Must end in .svg, .png, or .webp.",
+                  "pattern": "^(?!http:)(?:https://)?[^\\s]+\\.(?:svg|png|webp)$"
+                }
+              }
+            }
+          ]
+        },
+        "category": {
+          "$comment": "One of BB's sixteen canonical categories. The list is closed: there is no Other.",
+          "enum": [
+            "themes-and-appearance",
+            "thread-lists-and-navigation",
+            "thread-messages-and-timelines",
+            "composer-and-prompts",
+            "memory-and-context",
+            "agent-tools",
+            "security",
+            "agents-and-providers",
+            "token-usage-and-cost",
+            "notifications-and-attention",
+            "code-and-reviews",
+            "files-and-viewers",
+            "machines-and-hosts",
+            "plugin-development",
+            "task-tracking",
+            "automation"
+          ]
+        },
+        "screenshots": {
+          "type": "array",
+          "maxItems": 6,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "$comment": "An https URL or a relative .png/.jpg/.jpeg/.webp asset in this repository.",
+            "pattern": "^(?:(?![A-Za-z][A-Za-z0-9+.-]*:)|(?=[Hh][Tt][Tt][Pp][Ss]:))[^\\s]*\\.(?:[Pp][Nn][Gg]|[Jj][Pp][Ee]?[Gg]|[Ww][Ee][Bb][Pp])(?:[?#][^\\s]*)?$"
+          }
+        },
+        "publishedAt": {
+          "type": "string",
+          "format": "date-time",
+          "$comment": "Derived at build time from the first commit of this entry file. Not author-supplied."
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "$comment": "Derived at build time from the latest commit of this entry file. Not author-supplied."
+        },
+        "tags": {
+          "type": "array",
+          "maxItems": 10,
+          "items": {
+            "type": "string",
+            "maxLength": 32,
+            "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+          }
+        },
+        "author": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name"
+          ],
+          "$comment": "Never put an email address here: the manifest is public and mirrored.",
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "github": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9](?:-?[A-Za-z0-9]){0,38}$"
+            },
+            "url": {
+              "type": "string",
+              "pattern": "^https://"
+            }
+          }
+        },
+        "source": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/npmSource"
+            },
+            {
+              "$ref": "#/$defs/gitRefSource"
+            },
+            {
+              "$ref": "#/$defs/gitRangeSource"
+            }
+          ]
+        }
+      }
+    },
+    "npmSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "npm"
+      ],
+      "properties": {
+        "npm": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "package"
+          ],
+          "$comment": "range and tag are mutually exclusive.",
+          "not": {
+            "required": [
+              "range",
+              "tag"
+            ]
+          },
+          "properties": {
+            "package": {
+              "type": "string",
+              "pattern": "^(?:@[a-z0-9][a-z0-9._~-]*/)?[a-z0-9][a-z0-9._~-]*$"
+            },
+            "range": {
+              "type": "string",
+              "minLength": 1
+            },
+            "tag": {
+              "type": "string",
+              "pattern": "^[A-Za-z][A-Za-z0-9._-]*$"
+            },
+            "registry": {
+              "type": "string",
+              "pattern": "^https://"
+            }
+          }
+        }
+      }
+    },
+    "gitSubdir": {
+      "type": "string",
+      "$comment": "Repository-relative directory; absolute paths, empty segments, .. and .git are rejected.",
+      "pattern": "^(?![A-Za-z]:)(?!/)(?!(?:[^/]+/)*(?:\\.|\\.\\.|\\.git)(?:/|$))[^/\\\\]+(?:/[^/\\\\]+)*$"
+    },
+    "gitRefSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "git"
+      ],
+      "$comment": "One branch, tag, or commit. Mutually exclusive with the range form.",
+      "properties": {
+        "git": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "url",
+            "ref"
+          ],
+          "properties": {
+            "url": {
+              "type": "string",
+              "pattern": "^https://"
+            },
+            "subdir": {
+              "$ref": "#/$defs/gitSubdir"
+            },
+            "ref": {
+              "type": "string",
+              "$comment": "Must round-trip through BB's git:<url>@<ref> install syntax, so \":\" (which BB reads as a ref:/semver: selector) is rejected.",
+              "pattern": "^(?!-)(?![\\s\\S]*\\.\\.)(?![\\s\\S]*@)(?![\\s\\S]*:)[\\s\\S]+$"
+            }
+          }
+        }
+      }
+    },
+    "gitRangeSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "git"
+      ],
+      "$comment": "A semver range resolved over the repository's [tagPrefix]vX.Y.Z release tags. BB records the tag and commit it selected and refuses a tag that later points elsewhere.",
+      "properties": {
+        "git": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "url",
+            "range"
+          ],
+          "properties": {
+            "url": {
+              "type": "string",
+              "pattern": "^https://"
+            },
+            "subdir": {
+              "$ref": "#/$defs/gitSubdir"
+            },
+            "range": {
+              "type": "string",
+              "minLength": 1
+            },
+            "tagPrefix": {
+              "type": "string",
+              "$comment": "Monorepo tagging: \"notes/\" matches notes/vX.Y.Z tags. Omit for repository-wide vX.Y.Z tags.",
+              "maxLength": 128,
+              "pattern": "^(?!.*\\.\\.)(?!.*//)(?!.*\\/\\.)(?![^/]*\\.lock(?:/|$))(?!.*\\/[^/]*\\.lock(?:/|$))(?!.*\\.$)[A-Za-z0-9][A-Za-z0-9._/-]*$"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,13 +1,76 @@
 #!/usr/bin/env node
-// Compose entries/*.json + marketplace.base.json into dist/marketplace.json,
-// validating against schema/marketplace.schema.json. Exits non-zero on any
-// problem so CI can gate PRs. `--liveness` additionally checks that each git
-// source ref exists and each npm package is published.
+// Compose entries/*.json + marketplace.base.json into two manifests:
+//
+//   dist/marketplace.json      marketplace/v1 — the frozen contract
+//   dist/v2/marketplace.json   marketplace/v2 — the discovery catalog
+//
+// One entry file feeds both. An entry is the v2 shape, and v1 is a projection
+// of it that keeps exactly the seven fields v1 has always had. That direction
+// matters: released clients parse v1 strictly and reject any manifest carrying
+// a field they do not know, so a listing that gains `category` here must not
+// gain it there. The v1 schema is additionalProperties:false, so a leak fails
+// this build rather than shipping.
+//
+// Exits non-zero on any problem so CI can gate PRs. `--liveness` additionally
+// checks that each git source ref exists and each npm package is published.
 import { execFileSync } from "node:child_process";
 import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import Ajv from "ajv/dist/2020.js";
 import addFormats from "ajv-formats";
+
+/** Exactly the fields marketplace/v1 has ever carried. Never add to this. */
+const V1_ENTRY_FIELDS = new Set([
+  "id",
+  "displayName",
+  "description",
+  "icon",
+  "tags",
+  "author",
+  "source",
+]);
+
+/**
+ * Publication dates come from this repository's own history: an entry file's
+ * first commit is when that listing went live, its latest commit is when it
+ * last changed. Nothing here is author-supplied, so no one can backdate a
+ * listing onto the front of the "Recently added" shelf.
+ *
+ * A shallow clone would answer every query with the same one commit, which
+ * looks like a working build and publishes 82 identical timestamps. Refuse
+ * instead — the publish workflow checks out with fetch-depth: 0.
+ */
+function gitDates(root, file) {
+  const log = (args) =>
+    execFileSync("git", ["-C", root, "log", "--format=%aI", ...args], {
+      encoding: "utf8",
+      timeout: 30_000,
+    })
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+  const path = join("entries", file);
+  const added = log(["--diff-filter=A", "--follow", "--", path]);
+  const latest = log(["-1", "--", path]);
+  // A file that exists but has no commit yet is a local edit, not a listing.
+  // Dates are optional in v2, so omit them rather than invent one.
+  if (added.length === 0 || latest.length === 0) return {};
+  return { publishedAt: added.at(-1), updatedAt: latest[0] };
+}
+
+function assertFullHistory(root) {
+  const shallow = execFileSync(
+    "git",
+    ["-C", root, "rev-parse", "--is-shallow-repository"],
+    { encoding: "utf8", timeout: 30_000 },
+  ).trim();
+  if (shallow === "true") {
+    console.error(
+      "error: shallow clone — publication dates would all collapse to one commit. Check out with fetch-depth: 0.",
+    );
+    process.exit(1);
+  }
+}
 
 const root = new URL("..", import.meta.url).pathname;
 const liveness = process.argv.includes("--liveness");
@@ -15,6 +78,7 @@ const problems = [];
 
 const readJson = (path) => JSON.parse(readFileSync(path, "utf8"));
 const base = readJson(join(root, "marketplace.base.json"));
+assertFullHistory(root);
 
 const entryFiles = readdirSync(join(root, "entries"))
   .filter((name) => name.endsWith(".json"))
@@ -48,14 +112,77 @@ for (const file of entryFiles) {
   plugins.push(entry);
 }
 
-const manifest = { $schema: "https://getbb.app/schemas/marketplace.schema.json", ...base, plugins };
-
 const ajv = new Ajv({ allErrors: true, strict: false });
 addFormats(ajv);
-const validate = ajv.compile(readJson(join(root, "schema", "marketplace.schema.json")));
+const v1Schema = readJson(join(root, "schema", "marketplace.schema.json"));
+const v2Schema = readJson(join(root, "schema", "marketplace-v2.schema.json"));
+
+// Report a bad entry against its own file before it disappears into an array
+// index in a manifest-level error.
+const validateEntry = ajv.compile({ ...v2Schema.$defs.entry, $defs: v2Schema.$defs });
+for (const entry of plugins) {
+  if (validateEntry(entry)) continue;
+  for (const error of validateEntry.errors ?? []) {
+    problems.push(`${entry.id}.json: ${error.instancePath || "/"} ${error.message}`);
+  }
+}
+
+const { newAndNotable: curatedNotable, ...v1Base } = base;
+for (const entryId of curatedNotable ?? []) {
+  if (!seen.has(entryId)) {
+    problems.push(`marketplace.base.json: newAndNotable names unknown entry "${entryId}"`);
+  }
+}
+
+const manifest = {
+  $schema: "https://getbb.app/schemas/marketplace.schema.json",
+  ...v1Base,
+  plugins: plugins.map((entry) =>
+    Object.fromEntries(
+      Object.entries(entry).filter(([field]) => V1_ENTRY_FIELDS.has(field)),
+    ),
+  ),
+};
+
+const v2Plugins = plugins.map((entry) => ({
+  ...entry,
+  ...gitDates(root, `${entry.id}.json`),
+}));
+
+/**
+ * The shelf bb renders as "New & notable", most notable first. Curate it by
+ * setting `newAndNotable` in marketplace.base.json; a curated list is used
+ * verbatim. Left unset it falls back to the newest listings, so the shelf
+ * stays populated and current on its own rather than decaying into whichever
+ * plugins someone hand-picked once.
+ */
+const NEW_AND_NOTABLE_FALLBACK_SIZE = 6;
+const newAndNotable =
+  curatedNotable ??
+  v2Plugins
+    .filter((entry) => entry.publishedAt !== undefined)
+    .sort((left, right) => right.publishedAt.localeCompare(left.publishedAt))
+    .slice(0, NEW_AND_NOTABLE_FALLBACK_SIZE)
+    .map((entry) => entry.id);
+
+const v2Manifest = {
+  $schema: "https://getbb.app/schemas/marketplace-v2.schema.json",
+  ...v1Base,
+  schemaVersion: 2,
+  newAndNotable,
+  plugins: v2Plugins,
+};
+
+const validate = ajv.compile(v1Schema);
 if (!validate(manifest)) {
   for (const error of validate.errors ?? []) {
-    problems.push(`schema: ${error.instancePath || "/"} ${error.message}`);
+    problems.push(`schema v1: ${error.instancePath || "/"} ${error.message}`);
+  }
+}
+const validateV2 = ajv.compile(v2Schema);
+if (!validateV2(v2Manifest)) {
+  for (const error of validateV2.errors ?? []) {
+    problems.push(`schema v2: ${error.instancePath || "/"} ${error.message}`);
   }
 }
 
@@ -115,10 +242,21 @@ if (problems.length > 0) {
 }
 
 const bytes = JSON.stringify(manifest, null, 2) + "\n";
-if (Buffer.byteLength(bytes, "utf8") > 1_048_576) {
-  console.error("error: composed manifest exceeds 1 MiB");
-  process.exit(1);
+const v2Bytes = JSON.stringify(v2Manifest, null, 2) + "\n";
+for (const [label, payload] of [
+  ["marketplace.json", bytes],
+  ["v2/marketplace.json", v2Bytes],
+]) {
+  if (Buffer.byteLength(payload, "utf8") > 1_048_576) {
+    console.error(`error: composed ${label} exceeds 1 MiB`);
+    process.exit(1);
+  }
 }
-mkdirSync(join(root, "dist"), { recursive: true });
+mkdirSync(join(root, "dist", "v2"), { recursive: true });
 writeFileSync(join(root, "dist", "marketplace.json"), bytes);
+writeFileSync(join(root, "dist", "v2", "marketplace.json"), v2Bytes);
+const dated = v2Manifest.plugins.filter((entry) => entry.publishedAt !== undefined).length;
 console.log(`built dist/marketplace.json with ${plugins.length} entries`);
+console.log(
+  `built dist/v2/marketplace.json with ${plugins.length} entries (${dated} dated, ${newAndNotable.length} new & notable)`,
+);


### PR DESCRIPTION
bb has been able to read a v2 discovery catalog for a while — categories, screenshots, publication dates. Nothing has ever published one. So every client falls back to v1, and the store renders one undifferentiated pile of 82 plugins with no dates and no shelves. This publishes v2 beside v1.

## One entry file, two manifests

An entry is now the **v2** shape, and **v1 is a projection of it** that keeps exactly the seven fields v1 has always had.

That direction is the whole design. Released clients parse v1 strictly and reject any manifest carrying a field they don't recognise, so a listing that gains `category` here must not gain it there. Getting this backwards would freeze the catalog for every user who hasn't upgraded.

It isn't left to care: `schema/marketplace.schema.json` is `additionalProperties: false`, so a leak fails the build. I verified that by deleting the projection — the build stops with `schema v1: /plugins/0 must NOT have additional properties` rather than publishing.

**`dist/marketplace.json` is byte-identical to the build before this change** — same sha256, `4dff7746…`. v1 has not moved.

## Categories

The one new thing a submitter writes. The list is closed — sixteen categories, no "Other" — which is what lets the store show real shelves instead of a pile.

All 82 existing listings are filed from a review of what each plugin actually does, not from its tags. The spread is even enough to be useful: 10 in Thread Lists & Navigation, 8 in Token Usage & Cost, 7 each in Themes, Timelines, Code & Reviews, and Machines & Hosts, down to 1 in Security. Every one of the sixteen is used.

## Dates are derived, not declared

`publishedAt` and `updatedAt` come from this repository's own history — an entry file's first commit is when that listing went live, its latest commit is when it last changed.

Author-supplied dates would be a claim; these are a record. Nobody can backdate themselves onto the front of "Recently added", and there's no date to keep in sync by hand. All 82 entries date cleanly, spanning 2026-08-14 to 2026-08-25.

The catch is that it needs full git history. **A shallow clone would answer every query with the same single commit and publish 82 identical timestamps** — a build that looks perfectly healthy and is entirely wrong. Both workflows now check out with `fetch-depth: 0`, and the build refuses to run shallow rather than trust the answer:

```
error: shallow clone — publication dates would all collapse to one commit. Check out with fetch-depth: 0.
```

## New & notable

Curated when `marketplace.base.json` sets `newAndNotable`, and falls back to the six newest listings when it doesn't — so the shelf is populated today and stays current without anyone remembering to tend it. Setting the key pins it.

## Publishing

v1 keeps its bucket-root key, because released clients already fetch it. v2 goes to `v2/marketplace.json`, which getbb.app serves at `/marketplace/v2/marketplace.json`. Icons still upload first, so no manifest ever references a missing object.

## Validation

- `dist/marketplace.json` byte-identical to the pre-change build (sha256 match)
- Both artifacts parsed with **bb's own shipped parsers**, not just the JSON schemas: the v2 manifest through `parseMarketplaceV2Manifest`, and every v1 entry through the frozen `marketplaceEntryV1Schema`. 82 entries, 16 categories, 82 dated, 6 notable — all accepted
- Negative paths each fail the build with a pointed message: invalid category, unknown field in an entry, `newAndNotable` naming a missing entry, a shallow clone, and a broken v1 projection
- `npm run build` clean from a full clone

## Follow-ups, not in this PR

- **Screenshots.** The field and its validation ship here; no listing declares one yet, and relative screenshot assets will need an upload step beside `icons/` when the first one does.
- **Category review.** These 82 assignments are my read of each plugin. Reviewers who know a plugin better should correct it — it's a one-line change per entry.

BB-Thread-ID: thr_yrs6swfgtc

🤖 Generated with [Claude Code](https://claude.com/claude-code)
