### PR TITLE
Add plugin entry: companion-chat

### DIFF
--- a/entries/companion-chat.json
+++ b/entries/companion-chat.json
@@ -1,0 +1,18 @@
+{
+  "id": "companion-chat",
+  "displayName": "Companion Chat",
+  "description": "Opens a fresh companion thread beside your current BB conversation, with independent provider and model selection and the current worktree preselected.",
+  "icon": "SideChat",
+  "tags": ["agents", "interface", "providers", "threads", "workspace"],
+  "author": {
+    "name": "Divyesh",
+    "github": "divyesh-puri",
+    "url": "https://github.com/divyesh-puri"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/divyesh-puri/bb-plugin-companion-chat.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/entries/companion-chat.json
+++ b/entries/companion-chat.json
@@ -1,7 +1,7 @@
 {
   "id": "companion-chat",
   "displayName": "Companion Chat",
-  "description": "Opens a fresh companion thread beside your current BB conversation, with independent provider and model selection and the current worktree preselected.",
+  "description": "Opens a fresh hidden thread beside the current BB conversation with independent provider and model selection, keeping it out of the sidebar unless the user later makes it visible.",
   "icon": "SideChat",
   "tags": ["agents", "interface", "providers", "threads", "workspace"],
   "author": {


### PR DESCRIPTION
## What it adds

Companion Chat opens a fresh thread beside the current bb conversation. The new thread starts in the current project and worktree, lets the user choose any installed provider and model independently, and stays in the originating panel without adding a top-level sidebar entry.

This is a new conversation, not a fork of the source provider session.

## Release

- Source: `https://github.com/divyesh-puri/bb-plugin-companion-chat.git`
- Release: `v0.1.1`
- Marketplace range: `^0.1.0`
- Release commit: `8d7d508981fd44cbf5ca73a8a41ddef83d6f9bca`

## Validation

- 6 Vitest tests pass
- TypeScript typecheck passes
- `bb plugin build` passes
- Clean checkout of `v0.1.1` installs production dependencies and builds both server and app bundles
- Marketplace schema build passes with 82 entries
- Marketplace liveness validates the Companion Chat Git source and release; the repository-wide command currently exits nonzero on two unrelated existing npm entries, `taskboard` and `usage-tracker`, which were unpublished upstream

## Security

Companion Chat is a full-trust bb plugin. It uses bb's native thread and composer APIs, requires no credentials, and connects to no external service.

Companion threads use BB's hidden-thread visibility so they remain in the originating panel without adding top-level sidebar entries.
