### PR TITLE
Add plugin entry: harness

### DIFF
--- a/entries/harness.json
+++ b/entries/harness.json
@@ -1,0 +1,27 @@
+{
+  "id": "harness",
+  "displayName": "Harness",
+  "description": "Adds an opt-in Explore, Plan, Worker, Critic, and Promote workflow to BB threads with explicit DAGs, role routing, audit artifacts, and custom Harness definitions.",
+  "icon": {
+    "url": "./icons/harness-80394649.svg"
+  },
+  "tags": [
+    "agents",
+    "developer-tools",
+    "workflows",
+    "planning",
+    "reviews",
+    "orchestration"
+  ],
+  "author": {
+    "name": "lutfikeskin",
+    "github": "lutfikeskin",
+    "url": "https://github.com/lutfikeskin"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/lutfikeskin/bb-plugin-harness.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/entries/harness.json
+++ b/entries/harness.json
@@ -21,7 +21,7 @@
   "source": {
     "git": {
       "url": "https://github.com/lutfikeskin/bb-plugin-harness.git",
-      "range": "^0.1.0"
+      "range": "^0.1.1"
     }
   }
 }

--- a/icons/harness-80394649.svg
+++ b/icons/harness-80394649.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 16c2.5-6 5.5-9 9-9s6.5 3 9 9"/>
+  <circle cx="4" cy="15.2" r="1.4" fill="currentColor" stroke="none"/>
+  <circle cx="8" cy="9.6" r="1.4" fill="currentColor" stroke="none"/>
+  <circle cx="12" cy="7" r="1.4" fill="currentColor" stroke="none"/>
+  <circle cx="16" cy="9.6" r="1.4" fill="currentColor" stroke="none"/>
+  <circle cx="20" cy="15.2" r="1.4" fill="currentColor" stroke="none"/>
+</svg>


### PR DESCRIPTION
## What the plugin does

Harness adds an opt-in Explore, Plan, Worker, Critic, and Promote workflow to BB threads with explicit DAGs, provider/model routing, visible role children, audit artifacts, and custom Harness definitions.

## Release source

- Git: `https://github.com/lutfikeskin/bb-plugin-harness.git`
- Licensed release: `v0.1.1` at `d1a096edcd7ff7be6ea572963450c2904ea70a24`
- Marketplace range: `^0.1.1`
- License: MIT (`LICENSE` plus `license: MIT` in `package.json`)

## Plugin checks

- 59/59 tests passed
- TypeScript typecheck passed
- BB Plugin SDK 0.4.21 compatibility check passed
- BB plugin build passed
- Reload and disable/enable smoke checks passed
- Independent final review: APPROVE

## Marketplace checks

- Rebased onto current `get-bb/marketplace:main`
- `npm run build` passed with 88 entries
- `npm run check` passed, including Harness Git release liveness
- Vendored SVG icon is 565 bytes and script-free

## Security and external services

Harness uses BB's existing thread, environment, provider, model, file, and plugin storage APIs. It does not require credentials or external services. Ordinary chats remain unchanged until the user explicitly starts Harness.
