### PR TITLE
Add Claude Account Switcher

### DIFF
--- a/entries/claude-account-switcher.json
+++ b/entries/claude-account-switcher.json
@@ -1,0 +1,18 @@
+{
+  "id": "claude-account-switcher",
+  "displayName": "Claude Account Switcher",
+  "description": "Switches one BB Claude Code thread to the verified Claude subscription login on its machine while preserving thread history.",
+  "icon": "UserSwitch",
+  "tags": ["providers", "authentication", "oauth", "claude-code", "threads"],
+  "author": {
+    "name": "David Beyer",
+    "github": "benegessarit",
+    "url": "https://github.com/benegessarit"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/benegessarit/bb-plugin-claude-account-switcher.git",
+      "range": "^0.1.0"
+    }
+  }
+}


### PR DESCRIPTION
## Plugin

Claude Account Switcher lets someone change the machine-wide Claude subscription used by one BB Claude Code thread without throwing away the thread or its history.

It supports two paths:

- reuse the verified Claude subscription already signed in on the thread's machine
- sign in to another subscription through Claude Code's supported OAuth flow

The plugin keeps operation state on the server so the dialog can recover after a remount. It also owns and reconciles its login helper across plugin reloads.

## Source

- Repository: https://github.com/benegessarit/bb-plugin-claude-account-switcher
- Current release: https://github.com/benegessarit/bb-plugin-claude-account-switcher/releases/tag/v0.1.2
- Marketplace range: `^0.1.0`

## Verification

- the plugin's 106 backend tests and 28 UI tests pass
- BB's exact SDK compatibility check passes against public BB 0.40 on macOS and Linux
- the source repository has protected `main`, gitleaks, pre-commit checks, Dependabot, and private vulnerability reporting
- the marketplace entry passed the repository's local build and source-liveness validation before submission

## Security boundary

The plugin does not read browser passwords, the macOS Keychain, Claude credential files, account identity, or raw authentication output. OAuth and account selection remain in Claude's website and Claude Code. The source repository documents the remaining BB runtime-release race and the trusted host `PATH` boundary.
