### PR TITLE
Add plugin entry: vercel-theme

### DIFF
--- a/entries/vercel-theme.json
+++ b/entries/vercel-theme.json
@@ -1,0 +1,29 @@
+{
+  "id": "vercel-theme",
+  "displayName": "Vercel Theme",
+  "description": "Adds a Vercel-inspired light and dark palette with Geist typography and matching code, diff, file-tree, and terminal colors.",
+  "icon": {
+    "url": "./icons/vercel-theme-4b3ff44b.svg"
+  },
+  "tags": [
+    "theme",
+    "dark",
+    "light",
+    "vercel",
+    "geist",
+    "syntax-highlighting",
+    "terminal",
+    "interface"
+  ],
+  "author": {
+    "name": "Divyesh Puri",
+    "github": "divyesh-puri",
+    "url": "https://github.com/divyesh-puri"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/divyesh-puri/bb-plugin-vercel-theme.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/icons/vercel-theme-4b3ff44b.svg
+++ b/icons/vercel-theme-4b3ff44b.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <rect x="3" y="3" width="8" height="8" rx="2" fill="#171717" stroke="#888888"/>
+  <rect x="13" y="3" width="8" height="8" rx="2" fill="#ededed" stroke="#888888"/>
+  <rect x="3" y="13" width="8" height="8" rx="2" fill="#ededed" stroke="#888888"/>
+  <rect x="13" y="13" width="8" height="8" rx="2" fill="#171717" stroke="#888888"/>
+</svg>


### PR DESCRIPTION
## What this plugin does

Vercel Theme adds a Vercel-inspired light and dark palette to bb with Geist typography, true-black dark surfaces, restrained blue interaction accents, and coordinated code, diff, file-tree, and terminal colors.

The plugin is an independent community theme and is not affiliated with or endorsed by Vercel.

## Release

- Source: `https://github.com/divyesh-puri/bb-plugin-vercel-theme.git`
- Release: `v0.1.0`
- Range: `^0.1.0`

## Plugin checks

- `npm run check`
- `npm run build`
- `npm pack --dry-run --ignore-scripts`
- Local path install and reload on bb 0.40.0
- Live browser QA in both dark and light modes
- Independent release-readiness review

## Marketplace checks

- `npm ci --ignore-scripts`
- `npm run build`
- `npm run check` after the public Git tag is available

## Security and permissions

This is a theme-only plugin. It has no settings, services, schedules, CLI commands, network access, external services, secrets, or data storage. Its backend only logs that the theme registered.
