### PR TITLE
Add plugin entry: handsfree

### DIFF
--- a/entries/handsfree.json
+++ b/entries/handsfree.json
@@ -1,7 +1,7 @@
 {
-  "id": "realtime",
-  "displayName": "Realtime",
-  "description": "Adds a realtime voice operator to bb: talk to an agent that focuses threads, sends messages, starts work, and shows diffs.",
+  "id": "handsfree",
+  "displayName": "Handsfree",
+  "description": "Adds a hands-free voice operator to bb: talk to an agent that focuses threads, sends messages, starts work, and shows diffs.",
   "icon": "AudioLines",
   "tags": [
     "voice",
@@ -17,7 +17,7 @@
   },
   "source": {
     "git": {
-      "url": "https://github.com/swairshah/bb-realtime.git",
+      "url": "https://github.com/swairshah/bb-handsfree.git",
       "range": "^0.1.0"
     }
   }

--- a/entries/realtime.json
+++ b/entries/realtime.json
@@ -1,0 +1,24 @@
+{
+  "id": "realtime",
+  "displayName": "Realtime",
+  "description": "Adds a realtime voice operator to bb: talk to an agent that focuses threads, sends messages, starts work, and shows diffs.",
+  "icon": "AudioLines",
+  "tags": [
+    "voice",
+    "realtime",
+    "agent",
+    "interface",
+    "audio"
+  ],
+  "author": {
+    "name": "Swair Shah",
+    "github": "swairshah",
+    "url": "https://github.com/swairshah"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/swairshah/bb-realtime.git",
+      "range": "^0.1.0"
+    }
+  }
+}


### PR DESCRIPTION
## What the plugin does
Handsfree adds a gpt-realtime voice operator to bb: the user talks to an agent that focuses threads, sends messages, starts work, and shows diffs.

## Source release
- Git: https://github.com/swairshah/bb-handsfree.git
- Latest tag `v0.1.3`, entry range `^0.1.0`

## Plugin checks
- `bb plugin build` succeeds (dist server/app bundles produced)
- Clean working tree at release commits

## Marketplace checks
- `npm run build` and `npm run check` succeed (88 entries)

## Permissions / external services
- Uses a realtime voice API for speech sessions; requires the user's own API credentials
- Interacts with bb threads via the plugin SDK (focus, message, start work, diffs)
