### PR TITLE
Add plugin entry: files-editor (Project View)

### DIFF
--- a/entries/files-editor.json
+++ b/entries/files-editor.json
@@ -1,0 +1,27 @@
+{
+  "id": "files-editor",
+  "displayName": "Files",
+  "description": "Browse and edit the workspace behind a thread in an editor layout: a searchable file tree on the left, tabs across the top, and the whole file in the middle. Opens as a full-page panel or as a tab beside a thread, where it is pinned to that thread's worktree so it shows the files the agent is editing. Cmd+P ranks files by path; clicking one opens it in its own tab, syntax-highlighted in your BB code theme. Saves are guarded by the hash the file had when it was opened, so an edit an agent made underneath you stops the save and offers Reload or Overwrite. For a workspace on the machine BB runs on it walks the directory itself, so dotfiles appear. Adds a `bb files` command that gives agents the same listing, which reads the right disk when the workspace is on another machine.",
+  "icon": {
+    "url": "./icons/files-editor-43529076.svg"
+  },
+  "tags": [
+    "files",
+    "editor",
+    "file-explorer",
+    "code",
+    "interface",
+    "developer-tools"
+  ],
+  "author": {
+    "name": "AbdElrahman Telb",
+    "github": "abdoutelb",
+    "url": "https://github.com/abdoutelb"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/abdoutelb/bb-plugin-files-editor.git",
+      "range": "^0.1.2"
+    }
+  }
+}

--- a/icons/files-editor-43529076.svg
+++ b/icons/files-editor-43529076.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <g fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round">
+    <rect x="2.5" y="3.5" width="19" height="17" rx="2.5" />
+    <path d="M9.5 3.5v17" />
+  </g>
+  <g fill="currentColor">
+    <rect x="5.1" y="7.4" width="2.6" height="1.5" rx="0.75" />
+    <rect x="5.1" y="11.25" width="2.6" height="1.5" rx="0.75" />
+    <rect x="5.1" y="15.1" width="2.6" height="1.5" rx="0.75" />
+    <rect x="11.5" y="7.4" width="7.4" height="1.5" rx="0.75" />
+    <rect x="11.5" y="11.25" width="5.2" height="1.5" rx="0.75" />
+    <rect x="11.5" y="15.1" width="6.6" height="1.5" rx="0.75" />
+  </g>
+</svg>


### PR DESCRIPTION
## What it does

Adds **Files**, a file explorer and editor for the workspace behind a bb thread,
laid out the way an editor is: a searchable tree on the left, tabs across the
top, and the whole file in the middle.

It registers a full-page nav panel and a thread-panel action. Beside a thread it
is pinned to that thread's worktree, so it shows the files the agent in that
conversation is editing. Cmd+P opens a ranked go-to-file palette; clicking a
file opens it in its own tab, syntax-highlighted with BB's own
`experimental_SourceCode` in the user's code theme. Saves are guarded by the
hash the file had when it was opened, so a change an agent made underneath the
user stops the save and offers Reload or Overwrite rather than clobbering it.

It also contributes a `bb files` command (`root`, `tree`, `find`, `read`) and a
skill that points agents at it, so an agent on a thread whose workspace lives on
another machine reads the right disk instead of the server's.

## Source release

- `https://github.com/abdoutelb/bb-plugin-files-editor.git`
- Range `^0.1.2`, resolving to tag `v0.1.2` (commit `b93431d`)
- Single plugin at the repository root: no `subdir`, no `tagPrefix`
- MIT

## Plugin checks

- `bb plugin build` — server and app bundles emit clean; the manifest's
  path-shaped SVG icon validates
- `tsc --noEmit` — clean
- `vitest run` — 67 tests pass (tree assembly, fuzzy ranking, workspace-relative
  path resolution, CLI output budgets, directory walking)
- Verified the git-install path specifically: fresh clone of the tag +
  `npm install --omit=dev` + `bb plugin build` succeeds, so nothing
  build-required sits in `devDependencies`

## Marketplace checks

- `npm ci --ignore-scripts`, `npm run build`, `npm run check` all succeed
  (88 entries)
- Icon vendored at `icons/files-editor-43529076.svg` (697 B, content-hashed).
  Single-colour SVG so BB's mask picks up the theme colour; no scripts, remote
  resources, or embedded data
- Entry id `files-editor` matches the id derived from the package name and the
  id the plugin manifest declares

## Permissions and security notes

- No network access, no external services, no credentials, no telemetry.
- All filesystem access goes through `bb.sdk.files` with `rootPath` confinement,
  so reads and writes stay inside the resolved workspace and are routed to the
  correct host rather than the server's disk. Relative paths from the client are
  resolved through a dedicated helper with traversal tests.
- One exception, deliberate and scoped: when the workspace resolves to the
  machine BB's own server runs on, the tree is listed with `node:fs` instead of
  `bb.sdk.files.listPaths`, because BB's listing drops every dotfile. Locality is
  decided by reading the daemon's own `<dataDir>/host-id` file, never by
  assuming "the only connected host". Anything not local goes through BB.
- Writes are compare-and-swap guarded; the plugin never writes without an
  explicit user action.
