### PR TITLE
Add plugin entry: bb-recap

### DIFF
--- a/entries/bb-recap.json
+++ b/entries/bb-recap.json
@@ -1,0 +1,25 @@
+{
+  "id": "bb-recap",
+  "displayName": "Recap",
+  "description": "Generates concise, display-only summaries for BB threads on demand or after they become idle.",
+  "icon": {
+    "url": "./icons/bb-recap-2f018e6b.svg"
+  },
+  "tags": [
+    "recap",
+    "summaries",
+    "threads",
+    "productivity"
+  ],
+  "author": {
+    "name": "MacHatter1",
+    "github": "MacHatter1",
+    "url": "https://github.com/MacHatter1"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/MacHatter1/bb-recap.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/icons/bb-recap-2f018e6b.svg
+++ b/icons/bb-recap-2f018e6b.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M6.25 4.75h11.5A2.25 2.25 0 0 1 20 7v7.25a2.25 2.25 0 0 1-2.25 2.25h-6.5L7 19.75V16.5H6.25A2.25 2.25 0 0 1 4 14.25V7a2.25 2.25 0 0 1 2.25-2.25Z" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M8.25 9h7.5M8.25 12h5.25" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## What this plugin does

Recap generates concise, display-only summaries for BB threads on demand or after they become idle. It stores summaries in its own namespaced database and exposes BB UI and CLI controls.

## Source release

- Repository: https://github.com/MacHatter1/bb-recap
- Release: `v0.1.0`
- Marketplace range: `^0.1.0`
- Reviewed commit: `6034c749549ab555430b64706b8b93feefed1bda`

## Validation

- `npm test` (5/5)
- `npx tsc --noEmit`
- `bb plugin types --check .`
- `bb plugin build .`
- Clean public clone: `npm ci --omit=dev --omit=optional --ignore-scripts`; `bb plugin build .`
- Marketplace: `npm ci --ignore-scripts`; `npm run build`; `npm run check`; `git diff --check`

## Permissions and security

Recap has no direct external network, filesystem, subprocess, telemetry, or synchronization service. It uses BB's configured provider and model through the normal BB runtime. Generation creates a hidden BB worker using Accept Edits mode; the worker is instructed to summarize only, and every worker is archived and stopped after completion. Transcripts are bounded, escaped, and marked untrusted. Auto-cleanup only removes Recap's own database rows.
