### PR TITLE
Add plugin entry: sentry-issues

### DIFF
--- a/entries/sentry-issues.json
+++ b/entries/sentry-issues.json
@@ -1,0 +1,29 @@
+{
+  "id": "sentry-issues",
+  "displayName": "Sentry Issues",
+  "description": "Browses bounded, read-only Sentry issue snapshots across configured projects and opens searchable issue detail with optional local BB triage links.",
+  "icon": {
+    "url": "./icons/sentry-issues-808083db.svg"
+  },
+  "tags": [
+    "sentry",
+    "issues",
+    "observability",
+    "error-monitoring",
+    "debugging",
+    "triage",
+    "sync",
+    "read-only"
+  ],
+  "author": {
+    "name": "Tom",
+    "github": "MacHatter1",
+    "url": "https://github.com/MacHatter1"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/MacHatter1/bb-sentry-issues.git",
+      "range": "^0.1.2"
+    }
+  }
+}

--- a/icons/sentry-issues-808083db.svg
+++ b/icons/sentry-issues-808083db.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8">
+  <path d="M12 3v3"/>
+  <path d="M9 7 7 5m8 2 2-2"/>
+  <path d="M9 9.5C9 7.6 10.3 6 12 6s3 1.6 3 3.5v5C15 16.4 13.7 18 12 18s-3-1.6-3-3.5v-5Z"/>
+  <path d="M8 11H5m3 3H5m11-3h3m-3 3h3"/>
+  <path d="M9 17 7 19m8-2 2 2"/>
+</svg>


### PR DESCRIPTION
## What the plugin does

Sentry Issues adds a read-only BB sidebar panel for browsing bounded issue snapshots across configured Sentry connections and projects. It supports severity summaries, searchable issue details, and optional links to local BB triage threads.

## Source release

- Repository: https://github.com/MacHatter1/bb-sentry-issues
- Package: `bb-plugin-sentry-issues@0.1.2`
- Tag: `v0.1.2`
- Marketplace range: `^0.1.2`

## Plugin checks

- 50 tests pass.
- TypeScript check passes.
- `bb plugin types --check` passes against SDK `0.4.21`.
- Production bundle build passes.
- Production dependency audit reports 0 vulnerabilities.
- Exact `v0.1.2` clone installs with development dependencies omitted and builds successfully.
- Package dry run includes the manifest, README, showcase assets, source, and built `dist/` artifacts.

## Marketplace checks

- Marketplace build passes.
- Marketplace liveness check passes.
- The entry uses the vendored monochrome SVG icon in `icons/`.
- The entry author is `MacHatter1`, matching the submitting account.

## Permissions and security

- The plugin makes bounded `GET` requests only to configured Sentry URLs; it exposes no Sentry mutation controls.
- Auth tokens remain in BB protected secret storage and are never returned to the app or logged.
- Issue data is normalized, redacted for sensitive values, and bounded before storage or display.
- Optional triage is explicitly user initiated, requires a linked local BB checkout, and uses BB's `accept-edits` permission mode with confirmation.
