### PR TITLE
Add plugin entry: docker

### DIFF
--- a/entries/docker.json
+++ b/entries/docker.json
@@ -1,0 +1,29 @@
+{
+  "id": "docker",
+  "displayName": "Docker",
+  "description": "Manages the local Docker engine from the bb sidebar with live cards for containers, images, volumes, and networks — logs, bounded non-interactive exec output, and explicitly confirmed pruning — plus a read-only bb docker CLI with listings and cleanup for agents.",
+  "icon": "Container",
+  "tags": [
+    "docker",
+    "containers",
+    "images",
+    "volumes",
+    "networks",
+    "cli",
+    "sidebar",
+    "interface"
+  ],
+  "author": {
+    "name": "Griko Nibras",
+    "github": "grikomsn",
+    "url": "https://github.com/grikomsn"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/grikomsn/bb-plugins.git",
+      "subdir": "packages/bb-plugin-docker",
+      "range": "^0.1.0",
+      "tagPrefix": "docker/"
+    }
+  }
+}


### PR DESCRIPTION
## What the plugin does

`bb-plugin-docker` brings local Docker operations into bb:

- **Sidebar panel** — live cards for containers, images, volumes, and networks
  (polled from the connected bb host), with logs, bounded non-interactive exec
  results, and destructively-gated pruning (`--yes` confirmed cleanup).
- **`bb docker` CLI** — agent-friendly read-only listings (`ps`, `images`,
  `volumes`, `networks`, `info`) and explicitly confirmed prune commands for
  `system`, `images`, `volumes`, or `networks`.
- **Agent skill** — instructs agents when and how to use `bb docker`, and to
  never prune without user authorization.

No configuration in v1: it uses the first connected bb host and that host's
active Docker context.

## Source release

- Git source: `https://github.com/grikomsn/bb-plugins.git`, subdir
  `packages/bb-plugin-docker`, tagPrefix `docker/`
- Release: tag `docker/v0.1.0`, range `^0.1.0`
- The plugin is a single-package folder in a public monorepo; the tag points
  at the current `main` HEAD, and the entry installs only the subdir.

## Plugin checks that succeeded

- `npm run typecheck` (tsc --noEmit) — pass
- `bb plugin build .` (bb CLI 0.40.0) — pass
- Plugin source fully committed and pushed before tagging

## Marketplace checks that succeeded

- `npm run build` — contract + icon path validation, 88 entries
- `npm run check` — liveness: `docker/v0.1.0` tag confirmed at
  `https://github.com/grikomsn/bb-plugins.git`

## Permissions / security notes

- The plugin executes the `docker` CLI on the connected bb host via
  `child_process.execFile` (no shell interpolation). Destructive operations
  (remove, prune) require explicit user confirmation in the UI or `--yes` in
  the CLI, and the CLI refuses to prune without it.
- No external services, no telemetry, no network calls beyond the local Docker
  daemon.