### PR TITLE
Add plugin entry: homepage

### DIFF
--- a/entries/homepage.json
+++ b/entries/homepage.json
@@ -1,0 +1,24 @@
+{
+  "id": "homepage",
+  "displayName": "Homepage",
+  "description": "Starts new chats from configurable homepage project cards with manual sorting, pinning, renaming, hiding, activity sparklines, and artwork.",
+  "icon": "GridView",
+  "tags": [
+    "homepage",
+    "projects",
+    "new-thread",
+    "launcher",
+    "interface"
+  ],
+  "author": {
+    "name": "Yusuf Akbulut",
+    "github": "yusuf8834",
+    "url": "https://github.com/yusuf8834"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/yusuf8834/bb-homepage.git",
+      "range": "^0.2.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds Homepage to the BB Community marketplace. The plugin starts new chats from configurable homepage project cards with manual sorting, pinning, renaming, hiding, activity sparklines, and project artwork.

Release source: `https://github.com/yusuf8834/bb-homepage.git` at `^0.2.0`.

## Validation

- Plugin: 64 tests passed, TypeScript passed, SDK `0.4.29` check passed, and `bb plugin build` passed.
- Marketplace: `npm run build`, `npm run check`, and `git diff --check` passed.

## Permissions and security

The plugin reads BB project and thread metadata and project files used for artwork. It updates a project name only after the user chooses Rename. Pinned and hidden project IDs are stored in plugin KV storage, while manual ordering stays in browser storage. It uses no external services or credentials. Project images are size-bounded and path-checked, and SVG content is sanitized before serving.
