### PR TITLE
Add plugin entry: mane-control

### DIFF
--- a/entries/mane-control.json
+++ b/entries/mane-control.json
@@ -7,7 +7,7 @@
   },
   "tags": ["composer", "interface", "ponytail", "threads", "workflow"],
   "author": {
-    "name": "MacHatter1",
+    "name": "Tom",
     "github": "MacHatter1",
     "url": "https://github.com/MacHatter1"
   },

--- a/entries/mane-control.json
+++ b/entries/mane-control.json
@@ -1,0 +1,20 @@
+{
+  "id": "mane-control",
+  "displayName": "Mane Control",
+  "description": "Switches Ponytail modes from the BB thread composer and shows the current mode on the control.",
+  "icon": {
+    "url": "./icons/mane-control-45b639fa.svg"
+  },
+  "tags": ["composer", "interface", "ponytail", "threads", "workflow"],
+  "author": {
+    "name": "MacHatter1",
+    "github": "MacHatter1",
+    "url": "https://github.com/MacHatter1"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/MacHatter1/bb-plugin-mane-control.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/icons/mane-control-45b639fa.svg
+++ b/icons/mane-control-45b639fa.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+  <path d="M14 21c-4.5-5-1.5-8-1.5-8 .924 2.463 4 2 4 2l1.774 1.36a.9.9 0 0 0 1.197-.23l1.327-1.602a1.01 1.01 0 0 0-.068-1.313l-1.282-1.366a4.28 4.28 0 0 1-1.116-2.313c-.162-1.036-.832-2.036-1.445-2.628L16 6l1-3s-2.576.03-3.5 2C7.5 5.5 3 9.536 3 21"/>
+</svg>


### PR DESCRIPTION
## What it does

Mane Control adds a horse control beside the BB thread composer for switching Ponytail between Off, Lite, Full, and Ultra. It displays the current mode and styles the resulting mode commands in the timeline.

## Source release

- Git release: `v0.1.0`
- Marketplace range: `^0.1.0`
- Source: https://github.com/MacHatter1/bb-plugin-mane-control

## Validation

Plugin:

- `npm test`
- `npm run check`
- `bb plugin types --check .`
- `npm run build`

Marketplace:

- `npm ci --ignore-scripts`
- `npm run build`
- `npm run check` with an isolated npm cache

## Permissions and services

Mane Control requires the separate Ponytail plugin. It stores the selected mode per thread and sends the corresponding `/ponytail <mode>` command through BB when the user selects a mode. It uses no external service, account, API key, network request, filesystem access, or subprocess.
