### PR TITLE
Add plugin entry: prompt-log

### DIFF
--- a/entries/prompt-log.json
+++ b/entries/prompt-log.json
@@ -1,0 +1,30 @@
+{
+  "id": "prompt-log",
+  "displayName": "Prompt Log",
+  "description": "Lists every prompt you sent in a thread in a Prompts side-panel tab, newest first and grouped by day, with a filter, a marker on the prompt being worked on, and a button that puts any earlier prompt back in the composer.",
+  "icon": {
+    "url": "./icons/prompt-log-f852a04d.svg"
+  },
+  "tags": [
+    "prompt",
+    "history",
+    "threads",
+    "sidebar",
+    "interface",
+    "composer",
+    "filtering"
+  ],
+  "author": {
+    "name": "Pablo Oliva",
+    "github": "pablooliva",
+    "url": "https://github.com/pablooliva"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/pablooliva/bb-ide-session-prompts.git",
+      "subdir": "bb-plugin-prompt-log",
+      "range": "^0.1.0",
+      "tagPrefix": "prompt-log/"
+    }
+  }
+}

--- a/icons/prompt-log-f852a04d.svg
+++ b/icons/prompt-log-f852a04d.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Prompt Log">
+  <path d="M3 4.5 5.5 7 3 9.5"/>
+  <path d="M9 7h12"/>
+  <path d="M9 13h12"/>
+  <path d="M9 19h7"/>
+</svg>


### PR DESCRIPTION
## What the plugin does

**Prompt Log** adds a **Prompts** tab to the thread side panel listing every
prompt the user sent in that thread, newest first. When an agent's replies are
long, finding your own messages means scrolling back through walls of tool
output; this shows your prompts and only your prompts.

- Day-grouped rows (`Today` / `Yesterday` / `Aug 28`) with relative timestamps.
- A pulsing marker on the prompt currently being worked on, keyed to the newest
  prompt's identity in the *unfiltered* list, so a filter cannot mislabel an old
  row as in-flight.
- Case-insensitive filter with matches highlighted inside the 3-line clamp.
- A per-row button that puts that prompt back in the composer via
  `useComposer().setText(...)`.
- Live updates on `thread.active` / `thread.idle` / `thread.failed`, plus a 30s
  backstop tick that catches prompts queued into an already-running turn.

## Source release

- Repository: <https://github.com/pablooliva/bb-ide-session-prompts> (public)
- Subdirectory: `bb-plugin-prompt-log`
- Tag: `prompt-log/v0.1.0` → commit `8b64f80c2d5330cfd0d8ff6d26c5f87147dd8e98`
- Entry source: git range `^0.1.0` with `tagPrefix: "prompt-log/"`

The repository is set up for plugin-scoped tags so a second session plugin can
version independently later without changing this entry.

## Plugin checks

- `npm test` — 33 tests passing (vitest: backend harness + jsdom panel tests)
- `npm run typecheck` — `tsc --noEmit`, clean
- `bb plugin build` — succeeds (bb 0.40.0)

## Marketplace checks

- `npm run build` — passes; schema valid, entry id matches filename, relative
  icon resolves.
- `npm run check` — the `prompt-log` entry passes liveness; the tag resolves via
  `git ls-remote`. Note the run also reports a pre-existing failure for the
  unrelated `ports` entry, whose repository
  (`https://github.com/ramaaudra/bb-plugin-ports.git`) no longer answers
  unauthenticated. That is present on `main` before this change.

## Permissions and external services

None. The plugin makes no network calls and uses no external services. Its
server exposes a single RPC method, `listPrompts`, reading
`bb.sdk.threads.promptHistory({ threadId })` and `bb.sdk.threads.get(...).status`
through the plugin SDK. Runtime dependencies are `zod` and
`@radix-ui/react-slot` only. Text parts marked `visibility: "agent-only"` are
excluded, so bb-injected agent context is not displayed.

The icon is a vendored single-colour stroke SVG using `currentColor`; it
contains no scripts and no remote references.
