### PR TITLE
Add plugin entry: machine-model-preferences

### DIFF
--- a/entries/machine-model-preferences.json
+++ b/entries/machine-model-preferences.json
@@ -1,0 +1,9 @@
+{
+  "id": "machine-model-preferences",
+  "displayName": "Machine Model Preferences",
+  "description": "Stores provider, model, and reasoning selections separately for each BB host and provider.",
+  "icon": { "url": "./icons/machine-model-preferences-16cfc7bf.svg" },
+  "tags": ["preferences", "machines", "models", "providers", "reasoning"],
+  "author": { "name": "Mateo Cerquetella", "github": "MateoCerquetella", "url": "https://github.com/MateoCerquetella" },
+  "source": { "git": { "url": "https://github.com/MateoCerquetella/bb-plugins.git", "subdir": "plugins/machine-model-preferences", "range": "^0.1.0", "tagPrefix": "machine-model-preferences/" } }
+}

--- a/icons/machine-model-preferences-16cfc7bf.svg
+++ b/icons/machine-model-preferences-16cfc7bf.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect width="64" height="64" rx="14" fill="#7c3aed"/><path d="M18 22h28M18 32h18M18 42h28" stroke="white" stroke-width="6" stroke-linecap="round"/><circle cx="43" cy="32" r="5" fill="#fbbf24"/></svg>


### PR DESCRIPTION
## What this plugin does
Stores provider, model, and reasoning selections separately for each BB host and provider, with a settings section to inspect and clear them.

## Source release
https://github.com/MateoCerquetella/bb-plugins.git, subdirectory plugins/machine-model-preferences, tag prefix machine-model-preferences/, range ^0.1.0.

## Checks
The plugin typecheck, focused tests, and build passed. Marketplace schema build passed. Marketplace liveness currently reports an unrelated pre-existing missing repository.

## Permissions and security
The plugin uses browser localStorage only; it has no external services, credentials, or network access. It does not replace BB core picker behavior; upstream native integration is tracked in https://github.com/get-bb/bb/pull/1964.