### PR TITLE
Add plugin entry: recent-archives

### DIFF
--- a/entries/recent-archives.json
+++ b/entries/recent-archives.json
@@ -12,6 +12,7 @@
     "interface",
     "filters"
   ],
+  "category": "thread-management",
   "author": {
     "name": "Braedon Saunders",
     "github": "braedonsaunders",

--- a/entries/recent-archives.json
+++ b/entries/recent-archives.json
@@ -1,0 +1,26 @@
+{
+  "id": "recent-archives",
+  "displayName": "Recent Archives",
+  "description": "Adds a per-project Recently archived filter to the sidebar Display options menu that lists the newest archived threads under the project, previews them without restoring, and unarchives from the row or thread header.",
+  "icon": {
+    "url": "./icons/recent-archives-63523030.svg"
+  },
+  "tags": [
+    "sidebar",
+    "archive",
+    "threads",
+    "interface",
+    "filters"
+  ],
+  "author": {
+    "name": "Braedon Saunders",
+    "github": "braedonsaunders",
+    "url": "https://github.com/braedonsaunders"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/braedonsaunders/bb-plugin-recent-archives.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/icons/recent-archives-63523030.svg
+++ b/icons/recent-archives-63523030.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path
+    d="M4 8h16l-1.2 11.2A2 2 0 0 1 16.81 21H7.19a2 2 0 0 1-1.99-1.8L4 8Z"
+    stroke="currentColor"
+    stroke-width="1.8"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M3 8h18l-1.4-3.1A2 2 0 0 0 17.76 3.5H6.24A2 2 0 0 0 4.4 4.9L3 8Z"
+    stroke="currentColor"
+    stroke-width="1.8"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M10 12.5v5M14 12.5v5"
+    stroke="currentColor"
+    stroke-width="1.8"
+    stroke-linecap="round"
+  />
+</svg>


### PR DESCRIPTION
## What the plugin does

Adds a per-project **Recently archived** filter to the sidebar Display options menu (next to Organize / Sort by). Turning it on shows the project's newest archived threads as a dimmed section at the bottom of that project's thread list. Clicking a row previews the thread without restoring it; Unarchive is available on the row (hover), in the archived-thread banner, and in the thread header. A "Show all N more" control expands past the newest few. Also registers a `bb recent-archives` CLI command (list/unarchive).

## Source release

- Repository: https://github.com/braedonsaunders/bb-plugin-recent-archives
- Tag: `v0.1.0` (annotated), range `^0.1.0`

## Plugin checks

- `npm test` — 7/7 unit tests pass
- `tsc --noEmit` — clean
- `bb plugin build` — builds `dist/app.js`, `dist/app.css`, `dist/app.meta.json`
- Installed and exercised end to end against a live BB (menu toggle, per-project section, preview, unarchive)

## Marketplace checks

- `npm run build` — succeeds, 90 entries
- `npm run check` — my entry's release tag is publicly visible (`git ls-remote --tags` shows `v0.1.0`); the run reports a pre-existing failure for the unrelated `ports` entry whose source repository no longer exists

## Security notes

- Frontend uses content scripts to inject the menu item and sidebar section into the BB app DOM; no external network calls
- Backend uses only the BB SDK thread APIs (list, get, open, unarchive) plus plugin settings and realtime
