### PR TITLE
xcode: require caller-scoped previews in ^0.3.2

### DIFF
--- a/entries/xcode.json
+++ b/entries/xcode.json
@@ -24,7 +24,7 @@
   "source": {
     "git": {
       "url": "https://github.com/vburojevic/bb-plugin-xcode.git",
-      "range": "^0.2.0"
+      "range": "^0.3.0"
     }
   }
 }

--- a/entries/xcode.json
+++ b/entries/xcode.json
@@ -24,7 +24,7 @@
   "source": {
     "git": {
       "url": "https://github.com/vburojevic/bb-plugin-xcode.git",
-      "range": "^0.3.0"
+      "range": "^0.3.2"
     }
   }
 }


### PR DESCRIPTION
Updates the Xcode entry from `^0.2.0` to `^0.3.2`, requiring the corrected preview-rendering release and allowing subsequent 0.3.x patches.

The earlier `simulator_stills` handler resolved `scopeForThread(null)`, which could select the first BB project and run build phases or capture previews in an unrelated checkout. [v0.3.2](https://github.com/vburojevic/bb-plugin-xcode/releases/tag/v0.3.2) fixes the review finding:

- Accepts the calling `PluginAgentToolContext` and resolves `scopeForThread(toolCtx.threadId)`.
- Refuses missing caller context, unresolved threads, and a resolved project that differs from the calling project before rendering.
- Adds 10 regression cases covering caller checkout/device routing and refusal paths.

Plugin fix: [2078acf](https://github.com/vburojevic/bb-plugin-xcode/commit/2078acf).

Validation: plugin TypeScript check and `bb plugin build` passed; 841 tests passed, 3 skipped. Marketplace `npm run build` passed with 111 entries. No live Xcode preview render was run for this change; the corrected tag is available for testing against this exact entry.
