### PR TITLE
Update MacHatter1 plugin marketplace entries

### DIFF
--- a/entries/bb-recap.json
+++ b/entries/bb-recap.json
@@ -19,7 +19,7 @@
   "source": {
     "git": {
       "url": "https://github.com/MacHatter1/bb-recap.git",
-      "range": "^0.1.0"
+      "range": "^0.2.0"
     }
   }
 }

--- a/entries/bb-recap.json
+++ b/entries/bb-recap.json
@@ -11,6 +11,7 @@
     "threads",
     "productivity"
   ],
+  "category": "thread-content",
   "author": {
     "name": "MacHatter1",
     "github": "MacHatter1",

--- a/entries/github-extended.json
+++ b/entries/github-extended.json
@@ -13,7 +13,7 @@
     "developer-tools"
   ],
   "author": {
-    "name": "Tom",
+    "name": "MacHatter1",
     "github": "MacHatter1",
     "url": "https://github.com/MacHatter1"
   },

--- a/entries/github-extended.json
+++ b/entries/github-extended.json
@@ -12,6 +12,7 @@
     "dependabot",
     "developer-tools"
   ],
+  "category": "code-and-reviews",
   "author": {
     "name": "MacHatter1",
     "github": "MacHatter1",

--- a/entries/mane-control.json
+++ b/entries/mane-control.json
@@ -6,6 +6,7 @@
     "url": "./icons/mane-control-45b639fa.svg"
   },
   "tags": ["composer", "interface", "ponytail", "threads", "workflow"],
+  "category": "tasks-and-workflows",
   "author": {
     "name": "MacHatter1",
     "github": "MacHatter1",

--- a/entries/mane-control.json
+++ b/entries/mane-control.json
@@ -7,7 +7,7 @@
   },
   "tags": ["composer", "interface", "ponytail", "threads", "workflow"],
   "author": {
-    "name": "Tom",
+    "name": "MacHatter1",
     "github": "MacHatter1",
     "url": "https://github.com/MacHatter1"
   },

--- a/entries/sentry-issues.json
+++ b/entries/sentry-issues.json
@@ -15,6 +15,7 @@
     "sync",
     "read-only"
   ],
+  "category": "code-and-reviews",
   "author": {
     "name": "MacHatter1",
     "github": "MacHatter1",

--- a/entries/sentry-issues.json
+++ b/entries/sentry-issues.json
@@ -16,7 +16,7 @@
     "read-only"
   ],
   "author": {
-    "name": "Tom",
+    "name": "MacHatter1",
     "github": "MacHatter1",
     "url": "https://github.com/MacHatter1"
   },


### PR DESCRIPTION
## Summary

- Update bb-recap from the ^0.1.0 source range to ^0.2.0 so the v0.2.0 release is discoverable.
- Normalise the display author to MacHatter1 for GitHub Extended, Mane Control, and Sentry Issues.
- Keep all existing MacHatter1 repository URLs and catalogue metadata unchanged.

## Validation

- npm run check (passes; 111 entries built and all source liveness checks completed).