### PR TITLE
Add plugin entry: bb-agent-toolbox

### DIFF
--- a/entries/bb-agent-toolbox.json
+++ b/entries/bb-agent-toolbox.json
@@ -1,0 +1,28 @@
+{
+  "id": "bb-agent-toolbox",
+  "displayName": "BB Agent Toolbox",
+  "description": "Gives any coding agent (opencode, Prime Agent, Google Antigravity, Codex, Claude Code, and more) direct tools for bb: read and edit workspace files, inspect and message other threads, delegate work by spawning threads, and see running terminals.",
+  "icon": {
+    "url": "./icons/bb-agent-toolbox-7ffa1afd.svg"
+  },
+  "tags": [
+    "agents",
+    "tools",
+    "threads",
+    "workspace",
+    "terminals",
+    "orchestration",
+    "multi-agent"
+  ],
+  "author": {
+    "name": "rawizhere",
+    "github": "rawizhere",
+    "url": "https://github.com/rawizhere"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/rawizhere/bb-plugin-bb-agent-toolbox.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/entries/bb-agent-toolbox.json
+++ b/entries/bb-agent-toolbox.json
@@ -14,6 +14,7 @@
     "orchestration",
     "multi-agent"
   ],
+  "category": "agents-and-providers",
   "author": {
     "name": "rawizhere",
     "github": "rawizhere",

--- a/icons/bb-agent-toolbox-7ffa1afd.svg
+++ b/icons/bb-agent-toolbox-7ffa1afd.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M8 2h8a1 1 0 0 1 1 1v3H7V3a1 1 0 0 1 1-1zM2 7h20v16H2zm0 5h20v1H2zm0 3h20v1H2zm0 3h20v1H2z"/></svg>


### PR DESCRIPTION
## What

Adds the **BB Agent Toolbox** plugin to the bb marketplace.

- **Plugin repo:** https://github.com/rawizhere/bb-plugin-bb-agent-toolbox
- **Package:** `bb-plugin-bb-agent-toolbox@0.1.0` (git source, range `^0.1.0`, tag `v0.1.0`)
- **Id:** `bb-agent-toolbox` (matches the manifest id derived from the package name)

## About the plugin

Exposes bb SDK surfaces as **provider-independent agent tools** via
`bb.agents.registerTool` + `bb.agents.contributeInstructions`. The tools are
injected into the sessions of any provider (opencode, Prime Agent, Google
Antigravity, Codex, Claude Code, and more), so an agent can act inside bb:

- **Threads** — `bbtools_threads_list` / `get` / `send` / `spawn` / `search`:
  inspect, message, and create bb threads to coordinate and delegate between
  agents.
- **Workspace** — `bbtools_projects_list` / `bbtools_workspace_list` / `read` /
  `write` / `mkdir`: orient across projects and read/write workspace files,
  confined to the thread's workspace root via `rootPath`.
- **Terminals** — `bbtools_terminals_list`: see running bb terminal sessions.

Shared memory is intentionally omitted: the built-in Memory plugin already
provides `bb_memory_*` agent tools, so this toolbox stays focused on what is
otherwise missing. Each tool group is toggleable via settings.

## Security / permissions

- The plugin makes **no network calls** from its own code and downloads
  nothing. It only exposes read/write surfaces through the existing bb SDK.
- Workspace reads/writes are confined to the current thread's workspace root.
- All tool groups are disabled by default except the three groups above; each
  can be turned off independently.

## Validation

- Plugin: `npm install --omit=dev --omit=optional` lands the SDK; `bb plugin
  build` passes; `tsc --noEmit` passes.
- Marketplace: `npm run build` passes (112 entries, no errors); `npm run
  check` (liveness) passes for this entry.
- Git source tag `v0.1.0` exists on the plugin repository and resolves.

---

> This is an automated submission prepared by a Prime Agent coding session in
> bb: plugin authored, built, and validated end-to-end, repository pushed, tag
> `v0.1.0` created, and this entry verified against the marketplace build and
> liveness checks.