### PR TITLE
Add plugin entry: dockside

### DIFF
--- a/entries/dockside.json
+++ b/entries/dockside.json
@@ -18,6 +18,7 @@
     "github": "MateoCerquetella",
     "url": "https://github.com/MateoCerquetella"
   },
+  "category": "thread-management",
   "source": {
     "git": {
       "url": "https://github.com/MateoCerquetella/bb-plugins.git",

--- a/entries/dockside.json
+++ b/entries/dockside.json
@@ -1,0 +1,29 @@
+{
+  "id": "dockside",
+  "displayName": "Dockside",
+  "description": "Organizes BB threads into compact project-first families with semantic status, inline child agents, and persistent drag ordering.",
+  "icon": {
+    "url": "./icons/dockside-0a2df40e.svg"
+  },
+  "tags": [
+    "sidebar",
+    "threads",
+    "projects",
+    "agents",
+    "status",
+    "productivity"
+  ],
+  "author": {
+    "name": "Mateo Cerquetella",
+    "github": "MateoCerquetella",
+    "url": "https://github.com/MateoCerquetella"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/MateoCerquetella/bb-plugins.git",
+      "subdir": "plugins/dockside",
+      "range": "^0.1.0",
+      "tagPrefix": "dockside/"
+    }
+  }
+}

--- a/icons/dockside-0a2df40e.svg
+++ b/icons/dockside-0a2df40e.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" color="#000">
+  <path d="M13 3H11C7.22876 3 5.34315 3 4.17157 4.17157C3 5.34315 3 7.22876 3 11V13C3 16.7712 3 18.6569 4.17157 19.8284C5.34315 21 7.22876 21 11 21H13C16.7712 21 18.6569 21 19.8284 19.8284C21 18.6569 21 16.7712 21 13V11C21 7.22876 21 5.34315 19.8284 4.17157C18.6569 3 16.7712 3 13 3Z" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+  <path d="M9 3V21" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+</svg>


### PR DESCRIPTION
## Plugin

Dockside replaces BB's thread sidebar with compact project-first families, semantic status presentation, inline child agents, parent-only pull-request metadata, and persistent project/family drag ordering.

## Release source

- Repository: `https://github.com/MateoCerquetella/bb-plugins.git`
- Subdirectory: `plugins/dockside`
- Release tag: `dockside/v0.1.0`
- Release commit: `b43e19ff009e2ba2d34db68d40048841f16e89d9`
- Marketplace range: `^0.1.0`
- Tag prefix: `dockside/`

## Validation

- Derived plugin ID: `dockside`
- Dockside tests: 192 passing across 54 suites
- Dockside TypeScript typecheck: passing
- `bb plugin build .`: passing
- Public Git tag and subdirectory: verified
- Marketplace schema/build: passing with 112 entries
- Marketplace source liveness check: passing
- Icon: theme-aware SVG, 578 bytes, SHA-256 `0a2df40e80832cbbb1903db6a4e57b17cd6882bcc8cb50f190c24bcffebfcc96`

## Permissions, services, and security

- Requires BB `>=0.36`; no account, API key, or external service is required.
- Uses BB's Plugin SDK for project/thread reads and guarded thread mutations.
- Browser-local settings and ordering are bounded and validated before use.
- Bulk deletion uses a server-authoritative preview, one-use expiring confirmation capability, descendant binding, and confirm-time protected-state revalidation.
- Custom semantic colors accept only normalized six-digit hex values.
- Installing the plugin does not activate it automatically; users explicitly select Dockside under BB's sidebar appearance settings.
