### PR TITLE
Add plugin entry: bb-office

### DIFF
--- a/entries/bb-office.json
+++ b/entries/bb-office.json
@@ -1,0 +1,30 @@
+{
+  "id": "bb-office",
+  "displayName": "BB Office",
+  "description": "Turns active BB threads into a draggable pixel-art office with live worker state, thread navigation, usage indicators, and agent-configurable behavior.",
+  "icon": {
+    "url": "./icons/bb-office-201f84a0.svg"
+  },
+  "tags": [
+    "threads",
+    "visualization",
+    "office",
+    "pixel-art",
+    "navigation",
+    "usage",
+    "customization"
+  ],
+  "author": {
+    "name": "Michael Yong",
+    "github": "ymichael",
+    "url": "https://github.com/ymichael"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/ymichael/bb-plugins.git",
+      "subdir": "plugins/bb-office",
+      "range": "^1.0.0",
+      "tagPrefix": "bb-office/"
+    }
+  }
+}

--- a/entries/bb-office.json
+++ b/entries/bb-office.json
@@ -14,6 +14,7 @@
     "usage",
     "customization"
   ],
+  "category": "thread-management",
   "author": {
     "name": "Michael Yong",
     "github": "ymichael",

--- a/icons/bb-office-201f84a0.svg
+++ b/icons/bb-office-201f84a0.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M2.5 9.5H13.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+  <path d="M17.5 9.5H21.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+  <path d="M9.5 21.5V9.5" stroke="currentColor" stroke-width="1.5"/>
+  <path d="M9.5 6.5V2.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+  <path d="M17 17C15 17 13 18.6223 13 21.5H10.5C6.72876 21.5 4.84315 21.5 3.67157 20.3284C2.5 19.1569 2.5 17.2712 2.5 13.5V10.5C2.5 6.72876 2.5 4.84315 3.67157 3.67157C4.84315 2.5 6.72876 2.5 10.5 2.5H13.5C17.2712 2.5 19.1569 2.5 20.3284 3.67157C21.5 4.84315 21.5 6.72876 21.5 10.5V17.8432C21.5 19.8628 19.8628 21.5 17.8432 21.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+</svg>


### PR DESCRIPTION
## What

Adds BB Office, a draggable pixel-art office that turns active BB threads into workers with live state, thread navigation, usage indicators, and agent-configurable behavior.

## Release source

- Repository: https://github.com/ymichael/bb-plugins.git
- Plugin subdirectory: `plugins/bb-office`
- Release tag: `bb-office/v1.0.0`
- Marketplace range: `^1.0.0`
- Release commit: `b2a8da0c497b9d63d525b061e2d22829686a9c57`

## Validation

- BB Office strict TypeScript check passed.
- BB Office test suite passed: 77 tests across 10 files.
- `bb plugin build` produced the app and server bundles.
- Marketplace schema build passed.
- Marketplace source-liveness check passed against the public release tag.

## Permissions and security

BB Office uses BB plugin APIs for thread state, navigation, realtime updates, settings, and provider-usage summaries. It stores only its global office configuration in plugin storage, sends no provider account email to the frontend, and uses no third-party service or credential. Included Pixel Agents code and art and the Hugeicons floorplan icon retain their MIT attribution and license notices.

> AGENT GENERATED
