### PR TITLE
Emit publishedAt for marketplace v2 entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ Each `pluginIds` value must name an entry and must occur only once.
 
 The first collection has the ID `new-and-notable`.
 An empty `pluginIds` array tells the build to select eight entries.
-The build uses the entry `publishedAt` value when it is present.
-Otherwise, the build uses the committer date of the first commit that added the entry file.
+The v2 document has a `publishedAt` value for each entry.
+The build derives this value from the first commit that added the entry file.
+The registry does not emit an `updatedAt` value.
+The empty collection fallback orders entries by the emitted `publishedAt` value.
 
 ## Screenshots and icons
 

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -11,9 +11,9 @@ import {
   checkRequiredCategories,
   findOrphanScreenshotFiles,
   fillEmptyCollections,
-  parseEntryAddedDates,
   projectV1Manifest,
   pullRequestEntryFiles,
+  readEntryAddedDates,
   validateAndRewriteIcon,
   validateScreenshotReference,
 } from "./marketplace-lib.mjs";
@@ -141,8 +141,16 @@ for (const entry of plugins) {
 }
 
 const referencedScreenshotFiles = new Set();
+const addedAtById = entryAddedDates();
 const v2Plugins = plugins.map((entry) => {
   const output = { ...entry };
+  delete output.updatedAt;
+  const publishedAt = addedAtById.get(entry.id);
+  if (publishedAt === undefined) {
+    delete output.publishedAt;
+  } else {
+    output.publishedAt = publishedAt;
+  }
   const iconResult = validateAndRewriteIcon(root, entry.icon);
   output.icon = iconResult.icon;
   for (const problem of iconResult.problems) {
@@ -169,41 +177,10 @@ for (const file of findOrphanScreenshotFiles(root, referencedScreenshotFiles)) {
 }
 
 function entryAddedDates() {
-  const needsFallback = (base.collections ?? []).some(
-    (collection) => collection.pluginIds?.length === 0,
-  );
-  if (!needsFallback) return new Map();
-
   try {
-    const shallow = execFileSync(
-      "git",
-      ["-C", root, "rev-parse", "--is-shallow-repository"],
-      { encoding: "utf8", timeout: 30_000 },
-    ).trim();
-    if (shallow === "true") {
-      problems.push(
-        "The repository is shallow. The build needs full Git history for the new-and-notable collection.",
-      );
-      return new Map();
-    }
-    const output = execFileSync(
-      "git",
-      [
-        "-C",
-        root,
-        "log",
-        "--diff-filter=A",
-        "--follow",
-        "--format=date:%cI",
-        "--name-only",
-        "--",
-        "entries/",
-      ],
-      { encoding: "utf8", timeout: 30_000 },
-    );
-    const dates = parseEntryAddedDates(output);
+    const dates = readEntryAddedDates(root);
     for (const { entry, file } of entryRecords) {
-      if (entry.publishedAt === undefined && !dates.has(entry.id)) {
+      if (!dates.has(entry.id)) {
         problems.push(`${file}: The Git history has no first addition date.`);
       }
     }
@@ -218,7 +195,6 @@ function entryAddedDates() {
 const collections = fillEmptyCollections(
   base.collections ?? [],
   v2Plugins,
-  entryAddedDates(),
 );
 const v1Manifest = projectV1Manifest(base, plugins);
 const v2Manifest = {

--- a/scripts/marketplace-lib.mjs
+++ b/scripts/marketplace-lib.mjs
@@ -527,12 +527,43 @@ export function parseEntryAddedDates(output) {
   return dates;
 }
 
-export function fillEmptyCollections(collections, plugins, addedAtById) {
+export function readEntryAddedDates(root) {
+  const shallow = execFileSync(
+    "git",
+    ["-C", root, "rev-parse", "--is-shallow-repository"],
+    { encoding: "utf8", timeout: 30_000 },
+  ).trim();
+  if (shallow === "true") {
+    throw new Error(
+      "The repository is shallow. The build needs full Git history for entry publication dates.",
+    );
+  }
+
+  const output = execFileSync(
+    "git",
+    [
+      "-C",
+      root,
+      "log",
+      "--diff-filter=A",
+      "--follow",
+      "--format=date:%cI",
+      "--name-only",
+      "--",
+      "entries/",
+    ],
+    { encoding: "utf8", timeout: 30_000 },
+  );
+  return parseEntryAddedDates(output);
+}
+
+export function fillEmptyCollections(collections, plugins) {
   const fallbackIds = [...plugins]
     .sort((left, right) => {
-      const leftDate = left.publishedAt ?? addedAtById.get(left.id);
-      const rightDate = right.publishedAt ?? addedAtById.get(right.id);
-      return timeValue(rightDate) - timeValue(leftDate) || left.id.localeCompare(right.id);
+      return (
+        timeValue(right.publishedAt) - timeValue(left.publishedAt) ||
+        left.id.localeCompare(right.id)
+      );
     })
     .slice(0, 8)
     .map((plugin) => plugin.id);

--- a/test/marketplace.test.mjs
+++ b/test/marketplace.test.mjs
@@ -23,6 +23,7 @@ import {
   projectV1Entry,
   projectV1Manifest,
   pullRequestEntryFiles,
+  readEntryAddedDates,
   validateAndRewriteIcon,
   validateScreenshotReference,
   v1GateDisposition,
@@ -58,15 +59,16 @@ function writeScreenshot(root, filename, bytes) {
   writeFileSync(join(root, "screenshots", "example-plugin", filename), bytes);
 }
 
-function runGit(root, args) {
+function runGit(root, args, options = {}) {
   return execFileSync("git", args, {
     cwd: root,
     encoding: "utf8",
     timeout: 30_000,
+    ...options,
   }).trim();
 }
 
-test("the v1 projection keeps only v1 fields", () => {
+test("the v1 projection stays unchanged when a v2 entry has dates", () => {
   const source = readJson("projection/source-entry.json");
   const expected = readJson("projection/v1-entry.json");
   assert.deepEqual(projectV1Entry(source), expected);
@@ -203,17 +205,11 @@ test("the pull request diff returns added and modified entry files", () => {
 test("an empty collection gets eight newest entries", () => {
   const plugins = Array.from({ length: 10 }, (_, index) => ({
     id: `plugin-${index}`,
+    publishedAt: new Date(Date.UTC(2026, 0, index + 1)).toISOString(),
   }));
-  const dates = new Map(
-    plugins.map((plugin, index) => [
-      plugin.id,
-      new Date(Date.UTC(2026, 0, index + 1)).toISOString(),
-    ]),
-  );
   const result = fillEmptyCollections(
     [{ id: "new", displayName: "New", pluginIds: [] }],
     plugins,
-    dates,
   );
   assert.deepEqual(result[0].pluginIds, [
     "plugin-9",
@@ -227,21 +223,16 @@ test("an empty collection gets eight newest entries", () => {
   ]);
 });
 
-test("the collection fallback mixes entry dates and uses an id tie-break", () => {
+test("the collection fallback uses publishedAt and an id tie-break", () => {
   const plugins = [
     { id: "alpha", publishedAt: "2026-03-01T00:00:00Z" },
-    { id: "beta" },
+    { id: "beta", publishedAt: "2026-04-01T00:00:00Z" },
     { id: "charlie", publishedAt: "2026-04-01T00:00:00Z" },
-    { id: "delta" },
+    { id: "delta", publishedAt: "2026-01-01T00:00:00Z" },
   ];
-  const addedDates = new Map([
-    ["beta", "2026-04-01T00:00:00Z"],
-    ["delta", "2026-01-01T00:00:00Z"],
-  ]);
   const result = fillEmptyCollections(
     [{ id: "new", displayName: "New", pluginIds: [] }],
     plugins,
-    addedDates,
   );
   assert.deepEqual(result[0].pluginIds, ["beta", "charlie", "alpha", "delta"]);
 });
@@ -256,6 +247,40 @@ test("the Git log parser keeps the first addition date", () => {
     "entries/example.json",
   ].join("\n"));
   assert.equal(dates.get("example"), "2026-04-01T00:00:00Z");
+});
+
+test("a later entry edit does not change its first addition date", () => {
+  const root = mkdtempSync(join(tmpdir(), "marketplace-date-test-"));
+  try {
+    runGit(root, ["init", "--quiet"]);
+    runGit(root, ["config", "user.email", "test@example.com"]);
+    runGit(root, ["config", "user.name", "Test User"]);
+    mkdirSync(join(root, "entries"));
+    writeFileSync(join(root, "entries", "example.json"), '{"version":1}\n');
+    runGit(root, ["add", "entries/example.json"]);
+    runGit(root, ["commit", "--quiet", "-m", "Add entry"], {
+      env: {
+        ...process.env,
+        GIT_AUTHOR_DATE: "2026-01-02T03:04:05+00:00",
+        GIT_COMMITTER_DATE: "2026-01-02T03:04:05+00:00",
+      },
+    });
+
+    writeFileSync(join(root, "entries", "example.json"), '{"version":2}\n');
+    runGit(root, ["add", "entries/example.json"]);
+    runGit(root, ["commit", "--quiet", "-m", "Edit entry"], {
+      env: {
+        ...process.env,
+        GIT_AUTHOR_DATE: "2026-02-03T04:05:06+00:00",
+        GIT_COMMITTER_DATE: "2026-02-03T04:05:06+00:00",
+      },
+    });
+
+    const dates = readEntryAddedDates(root);
+    assert.equal(dates.get("example"), "2026-01-02T03:04:05Z");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("the image reader finds PNG, JPEG, and WebP widths", () => {


### PR DESCRIPTION
## What changed

- The v2 build gets each entry addition date from one Git history walk.
- The build emits that date as `publishedAt` for each v2 plugin.
- The build does not emit `updatedAt`.
- The New & notable fallback sorts the emitted `publishedAt` values.
- The README describes the date source and the `updatedAt` policy.
- The tests cover the first addition date, later edits, v1 projection, and fallback order.

## Verification

- `npm run build`
- `npm test`
- `npm run gate:v1`
- `npm run check`
- All 111 generated v2 plugins have `publishedAt` and no `updatedAt`.
- The generated v1 document is byte-identical to the live v1 document.

> AGENT GENERATED
