### PR TITLE
Retry transient R2 uploads during marketplace publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,34 +13,30 @@ jobs:
       - uses: actions/setup-node@v4
         with: { node-version: 20 }
       - run: npm ci
+      - name: Install Wrangler 4.86.0
+        run: npm install --global wrangler@4.86.0
       - run: npm run build
       - name: Check frozen v1 entries
         if: github.event_name == 'push'
         run: npm run gate:v1
-      # Icons upload first so the manifest never references a missing object.
+      # Keep this order explicit: assets first, then v2, then v1.
       - name: Upload icons
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
         run: |
+          source scripts/r2-upload.sh
           shopt -s nullglob
           for icon in icons/*.svg icons/*.png icons/*.webp; do
-            npx wrangler@4 r2 object put "bb-marketplace/icons/$(basename "$icon")" \
+            r2_put_with_retry "bb-marketplace/icons/$(basename "$icon")" \
               --file "$icon" --remote
           done
-      - name: Upload manifest
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-        run: |
-          npx wrangler@4 r2 object put "bb-marketplace/marketplace.json" \
-            --file dist/marketplace.json \
-            --content-type application/json --remote
       - name: Upload screenshots
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
         run: |
+          source scripts/r2-upload.sh
           if [[ ! -d screenshots ]]; then
             exit 0
           fi
@@ -51,7 +47,7 @@ jobs:
               *.webp) content_type="image/webp" ;;
               *) echo "Unsupported screenshot file: $screenshot" >&2; exit 1 ;;
             esac
-            npx wrangler@4 r2 object put "bb-marketplace/v2/${screenshot#./}" \
+            r2_put_with_retry "bb-marketplace/v2/${screenshot#./}" \
               --file "$screenshot" --content-type "$content_type" --remote
           done < <(find screenshots -type f -print0 | sort -z)
       - name: Upload v2 manifest
@@ -59,6 +55,16 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          npx wrangler@4 r2 object put "bb-marketplace/v2/marketplace.json" \
+          source scripts/r2-upload.sh
+          r2_put_with_retry "bb-marketplace/v2/marketplace.json" \
             --file dist/v2/marketplace.json \
+            --content-type application/json --remote
+      - name: Upload v1 manifest
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          source scripts/r2-upload.sh
+          r2_put_with_retry "bb-marketplace/marketplace.json" \
+            --file dist/marketplace.json \
             --content-type application/json --remote

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/setup-node@v4
         with: { node-version: 20 }
       - run: npm ci
+      - name: Install Wrangler 4.86.0
+        run: npm install --global wrangler@4.86.0
       # Fails, and uploads nothing, when PostHog answers with no counts: the
       # last published sidecar keeps serving rather than being zeroed out.
       - name: Build stats.json
@@ -27,6 +29,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          npx wrangler@4 r2 object put "bb-marketplace/stats.json" \
+          source scripts/r2-upload.sh
+          r2_put_with_retry "bb-marketplace/stats.json" \
             --file dist/stats.json \
             --content-type application/json --remote

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:stats": "node scripts/build-stats.mjs",
     "check": "node scripts/build.mjs --liveness",
     "gate:v1": "node scripts/check-v1-gate.mjs",
-    "test": "node --test"
+    "test": "node --test && bash test/r2-upload-retry.test.sh"
   },
   "devDependencies": {
     "ajv": "^8.17.1",

--- a/scripts/r2-upload.sh
+++ b/scripts/r2-upload.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+r2_put_with_retry() {
+  local attempt=1
+  local max_attempts=4
+  local wrangler_bin="${WRANGLER_BIN:-wrangler}"
+  local -a delays=(2 5 10)
+
+  while true; do
+    if "$wrangler_bin" r2 object put "$@"; then
+      return 0
+    fi
+
+    if (( attempt >= max_attempts )); then
+      echo "R2 upload failed after $max_attempts attempts." >&2
+      return 1
+    fi
+
+    local delay="${delays[$((attempt - 1))]}"
+    echo "R2 upload attempt $attempt failed. Retry in $delay seconds." >&2
+    sleep "$delay"
+    ((attempt += 1))
+  done
+}

--- a/test/r2-upload-retry.test.sh
+++ b/test/r2-upload-retry.test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname "$0")/../scripts/r2-upload.sh"
+
+fake_attempts=0
+fake_failures=2
+observed_delays=()
+fake_wrangler() {
+  ((fake_attempts += 1))
+  if (( fake_attempts <= fake_failures )); then
+    return 1
+  fi
+}
+
+sleep() {
+  observed_delays+=("$1")
+}
+
+WRANGLER_BIN=fake_wrangler
+r2_put_with_retry "test-bucket/test-object" --file test-file --remote
+
+if (( fake_attempts != 3 )); then
+  echo "Expected 3 attempts, but received $fake_attempts." >&2
+  exit 1
+fi
+
+if [[ "${observed_delays[*]}" != "2 5" ]]; then
+  echo "Expected delays 2 and 5, but received ${observed_delays[*]}." >&2
+  exit 1
+fi
+
+fake_attempts=0
+fake_failures=4
+observed_delays=()
+if r2_put_with_retry "test-bucket/test-object" --file test-file --remote; then
+  echo "Expected the retry helper to fail after 4 attempts." >&2
+  exit 1
+fi
+
+if (( fake_attempts != 4 )); then
+  echo "Expected 4 attempts, but received $fake_attempts." >&2
+  exit 1
+fi
+
+if [[ "${observed_delays[*]}" != "2 5 10" ]]; then
+  echo "Expected delays 2, 5, and 10, but received ${observed_delays[*]}." >&2
+  exit 1
+fi
+
+echo "The retry tests passed."


### PR DESCRIPTION
## Root cause

The publish job started one Wrangler process for each object.
The job had no retry for a failed request.
Cloudflare returned API error 500 with code 10001 for the second icon.
Bash then stopped the job.
The first icon was new, but both manifests stayed old.
A partial upload is worse than a full failure because it mixes object versions.
Clients can then read a manifest and assets from different publish runs.

The coordinator rerun succeeded.
This result supports the transient error diagnosis.

## What changed

Every R2 upload now uses one shared retry function.
The function makes four attempts and waits 2, 5, and 10 seconds.
The publish job now uploads icons and screenshots before both manifests.
It uploads the v2 manifest before the v1 manifest.
Thus, the job does not publish a manifest until all referenced assets exist.
An old client receives the v1 manifest only after the v2 publish is ready.

The stats upload uses the same retry function.
Wrangler 4.86.0 is pinned and installed once in each job.
The bucket keys, triggers, and secrets did not change.

## Verification

- The YAML syntax check passed for both workflow files.
- `npm run build` passed.
- `npm test` passed all 25 Node tests and both shell retry cases.
- The fake command failed twice and then succeeded on attempt three.
- The exhaustion case failed after attempt four and used all three delays.
- `npm run gate:v1` passed.
- `npm run check` passed.
- `git diff --check` passed.
- No R2 write ran from this worktree.

> AGENT GENERATED
