### PR TITLE
Update provider-usage: track 0.8.0

### DIFF
--- a/entries/provider-usage.json
+++ b/entries/provider-usage.json
@@ -1,7 +1,7 @@
 {
   "id": "provider-usage",
   "displayName": "Provider Usage",
-  "description": "Shows how much of each provider's plan is left — every rate-limit window, percent remaining, and when it resets — plus a 7/30/90-day token chart covering every provider, from local transcripts and BB's own usage events.",
+  "description": "Shows how much of each provider's plan is left \u2014 every rate-limit window, percent remaining, and when it resets \u2014 plus a 7/30/90-day token chart covering every provider, from local transcripts and BB's own usage events.",
   "icon": {
     "url": "./icons/provider-usage-752e444b.svg"
   },
@@ -14,7 +14,7 @@
     "claude-code",
     "cursor",
     "opencode",
-    "sidebar"
+    "muse"
   ],
   "author": {
     "name": "Braedon Saunders",
@@ -25,7 +25,7 @@
   "source": {
     "git": {
       "url": "https://github.com/braedonsaunders/bb-plugin-provider-usage.git",
-      "range": "^0.4.0"
+      "range": "^0.8.0"
     }
   }
 }


### PR DESCRIPTION
The entry tracks `^0.4.0`, which for a 0.x version resolves to `>=0.4.0 <0.5.0`, so marketplace installs have been pinned four minors behind the released plugin. This moves it to `^0.8.0`.

Since 0.4.0 the plugin gained per-model limit buckets, Codex credit balance and banked resets, on-demand spend control, live token throughput, an opencode transcript scanner, and — in 0.8.0 — Muse Code as a tracked provider. `muse` replaces the stale `sidebar` tag.

Same owner (`braedonsaunders`), same source repository, no branding change. `node scripts/build.mjs` passes locally.

> AGENT GENERATED