### PR TITLE
Add plugin entry: receipts

### DIFF
--- a/entries/receipts.json
+++ b/entries/receipts.json
@@ -1,0 +1,31 @@
+{
+  "id": "receipts",
+  "displayName": "Receipts",
+  "description": "Tracks Claude Code, Codex, Hermes Agent, OpenCode, Pi and Cursor token usage with estimated API cost, broken down by model, project and day.",
+  "icon": {
+    "url": "./icons/receipts-0407ee57.svg"
+  },
+  "tags": [
+    "usage",
+    "costs",
+    "tokens",
+    "analytics",
+    "hermes",
+    "opencode",
+    "claude-code",
+    "codex",
+    "cursor"
+  ],
+  "author": {
+    "name": "Christopher Böbel",
+    "github": "ChrBoebel",
+    "url": "https://github.com/ChrBoebel"
+  },
+  "category": "token-usage-and-limits",
+  "source": {
+    "git": {
+      "url": "https://github.com/ChrBoebel/bb-plugin-receipts.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/icons/receipts-0407ee57.svg
+++ b/icons/receipts-0407ee57.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" fill-rule="evenodd" clip-rule="evenodd">
+  <path d="M5 3.5a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1V20l-1.75 1.5L15.5 20l-1.75 1.5L12 20l-1.75 1.5L8.5 20l-1.75 1.5L5 20V3.5Zm3.75 4a.75.75 0 0 0 0 1.5h6.5a.75.75 0 0 0 0-1.5h-6.5Zm0 4a.75.75 0 0 0 0 1.5h3.5a.75.75 0 0 0 0-1.5h-3.5Z"/>
+</svg>


### PR DESCRIPTION
## What it does

Receipts adds a sidebar page and a `bb receipts` command that show what each
coding agent cost, with 7/30/90-day windows, a daily chart, and a breakdown by
model, project and day.

It is a fork of [`iamEvanYT/bb-usage-page`](https://github.com/iamEvanYT/bb-usage-page)
(MIT, credited in the README and `LICENSE`, whose copyright notice is retained).
On top of that base it adds two usage sources that no listed plugin reads today:

- **Hermes Agent** — `~/.hermes/state.db`, including per-session
  `actual_cost_usd` and the billing provider.
- **OpenCode** — `~/.local/share/opencode/opencode.db`.

Hermes only fills `sessions.cwd` for CLI runs; sessions bb launches are ACP
sessions that record the directory inside `model_config`, and subagents record
none and inherit it via `parent_session_id`. Receipts resolves all three so
those sessions attribute to the right project instead of landing in *Unknown*.

## Source

`git`, `https://github.com/ChrBoebel/bb-plugin-receipts.git`, range `^0.1.0`.
Tag `v0.1.0` → commit `88faf798a6feb277c61f15c9e4e99145d785a430`.

## Plugin checks

- `npm ci` and `npx tsc -p . --noEmit` — clean.
- `bb plugin build .` — emits the server and app bundles.
- Verified end to end from a fresh `--depth 1 --branch v0.1.0` clone: `npm ci`,
  `bb plugin build .` and the typecheck all pass on a clean checkout.
- Installed and run against real data on bb 0.41.0; `bb receipts show` reports
  Claude Code, Codex, Hermes, Pi and OpenCode totals.
- Missing, non-file and non-SQLite database paths were tested explicitly: they
  return `missing`/`failed` with a sanitised message, never throw. Users
  without Hermes or OpenCode installed simply see no rows for them.

## Marketplace checks

- `npm ci --ignore-scripts`, `npm run build`, `npm run check` — all pass
  (123 entries; the liveness check resolves the public tag).
- The commit contains only `entries/receipts.json` and
  `icons/receipts-0407ee57.svg`.

## Permissions, services and security

- Reads only on the machine running the bb server: Claude Code, Codex and Pi
  transcripts, and the Hermes and OpenCode SQLite databases. Both databases are
  opened **read-only** through `node:sqlite` with a 1 s busy timeout, so a
  running agent is never blocked. Paths are overridable with `HERMES_STATE_DB`
  and `OPENCODE_DATABASE_PATH`.
- No prompt or message content is stored — only timestamps, model ids, token
  counts, cost and the working directory used for project attribution.
- Network: the LiteLLM model-rate table, cached on disk. Cursor support is
  **opt-in** and off by default; when enabled it reads Cursor's local
  `state.vscdb` read-only and holds a short-lived dashboard cookie in memory
  only. That behaviour is inherited unchanged from the upstream plugin.
- Durable state stays under `~/.bb/plugins/receipts/` and is regenerable cache.
