### PR TITLE
Add plugin entry: glass-sidebar

### DIFF
--- a/entries/glass-sidebar.json
+++ b/entries/glass-sidebar.json
@@ -1,0 +1,29 @@
+{
+  "id": "glass-sidebar",
+  "displayName": "Glass Sidebar",
+  "description": "Distinguishes focused, split, and idle sessions in bb with colored folders, drag-and-drop organization, live work, project identity, and lifecycle shelves.",
+  "icon": {
+    "url": "./icons/glass-sidebar-e2480dc4.svg"
+  },
+  "tags": [
+    "sidebar",
+    "sessions",
+    "thread-management",
+    "folders",
+    "workflows",
+    "projects",
+    "glass"
+  ],
+  "category": "thread-management",
+  "author": {
+    "name": "Luis Llenin",
+    "github": "luisllenin02",
+    "url": "https://github.com/luisllenin02"
+  },
+  "source": {
+    "git": {
+      "url": "https://github.com/luisllenin02/bb-plugin-glass-sidebar.git",
+      "range": "^1.0.0"
+    }
+  }
+}

--- a/icons/glass-sidebar-e2480dc4.svg
+++ b/icons/glass-sidebar-e2480dc4.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <rect x="3" y="3" width="18" height="18" rx="4" stroke="currentColor" stroke-width="1.8"/>
+  <path d="M9 3v18M12 8h6M12 12h6M12 16h4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## What it does

Glass Sidebar replaces the default thread list with a session-management
sidebar that clearly distinguishes the focused thread, other open split panes,
and idle threads. It adds colored folders with drag-and-drop organization, live
open-pane and running-work rows, workflow children, project glyphs and colors,
lifecycle shelves, search, bulk actions, and a read-only importer for existing
bb-sidebar data.

## Release source

- Repository: https://github.com/luisllenin02/bb-plugin-glass-sidebar
- Range: `^1.0.0`
- Latest release in range: https://github.com/luisllenin02/bb-plugin-glass-sidebar/releases/tag/v1.1.0

## Since this was opened

The entry itself is unchanged — it pins a range, not a version — but the plugin
has moved from `v1.0.0` to `v1.1.0`, which is what the range now resolves to:

- The lifecycle read no longer runs the auto-settle policy pass on every sidebar
  refresh; it runs on a cadence, on its schedule, and when a thread goes quiet,
  with pull-request lookups cached per environment.
- Rows are memoised with stable per-row bindings, menus build their content only
  when opened, and off-screen cards skip layout and paint until scrolled into
  view. On a 200-row inbox a full relayout drops from 650 ms to 22 ms and
  context-menu open time from 1.1 s to 0.45 s.
- Fixed a hook-order crash in the child-threads chip.
- Third-party notices now also credit Hugeicons and zod; internal development
  documents no longer ship with the plugin; the README is rewritten for someone
  installing it.

## Validation

- Plugin at `v1.1.0`: TypeScript typecheck, 10 Node contract tests, 395 Vitest
  tests across 63 files, and `bb plugin build` passed.
- Marketplace: `npm run build`, `npm test`, `npm run gate:v1`, and
  `npm run check` passed when this entry was submitted. Neither file in this PR
  has changed since.
- The entry uses the matching plugin id and a vendored 282-byte single-color SVG
  icon.

## Permissions and security

The plugin runs as trusted bb plugin code and uses bb's plugin APIs for its
thread, project, environment, lifecycle, and organization data. It has no
external service dependency, does not perform general background polling, and
does not collect or transmit user data. Its import command opens the legacy
stores read-only and does not delete or modify them.