### PR TITLE
Add plugin entry: terminal-jobs

### DIFF
--- a/entries/terminal-jobs.json
+++ b/entries/terminal-jobs.json
@@ -1,0 +1,26 @@
+{
+  "id": "terminal-jobs",
+  "displayName": "Terminal Jobs",
+  "description": "Runs terminal commands that outlive agent turns, keeps job records and output logs, and sends completion notices to the owning BB thread.",
+  "icon": "Terminal",
+  "tags": [
+    "terminal",
+    "background-jobs",
+    "notifications",
+    "automation",
+    "multi-machine",
+    "command-line"
+  ],
+  "author": {
+    "name": "Ryan Brown",
+    "github": "ryanbbrown",
+    "url": "https://github.com/ryanbbrown"
+  },
+  "category": "command-line",
+  "source": {
+    "git": {
+      "url": "https://github.com/ryanbbrown/bb-plugin-terminal-jobs.git",
+      "range": "^0.2.0"
+    }
+  }
+}


### PR DESCRIPTION
## What the plugin does

Terminal Jobs runs durable shell commands on selected POSIX BB hosts, keeps job records and output artifacts, and sends completion notices to the owning thread. Its CLI can run, watch, inspect, retry notifications, list recent jobs, and explicitly prune settled data. Jobs stop through BB's native terminal command.

## Release source

- Repository: https://github.com/ryanbbrown/bb-plugin-terminal-jobs.git
- Release tag: `v0.2.0`
- Marketplace range: `^0.2.0`
- Release commit: `fee1c9782376def0b17c100a1c510bf0bcd256eb`
- Compatibility: BB 0.41.0 or later, plugin SDK 0.4.34 or later, Node.js 22 or later, and POSIX target hosts

## Validation

- Plugin `npm run check` passed: exact SDK metadata, TypeScript, 95 tests, reproducible builds, package checks, and isolated path and Git installation smoke tests.
- The public release CI passed on Ubuntu and macOS: https://github.com/ryanbbrown/bb-plugin-terminal-jobs/actions/runs/33781929618
- Marketplace `npm run build`, `npm test`, `npm run gate:v1`, and `npm run check` passed.
- The entry id matches the derived plugin id, and the public source check resolves the released tag.

## Permissions and security

The plugin runs as full-trust BB server and host code. It starts user-specified commands on a selected POSIX BB host and stores job metadata in plugin SQLite plus mode-protected launch, output, and outcome files on that host. Command arguments and artifacts can contain sensitive data, so the documentation tells users not to put secrets in command arguments. Shell environment variables do not cross the host boundary. The plugin uses no third-party service or credential.

> AGENT GENERATED
