### PR TITLE
Add plugin entry: x-viral

### DIFF
--- a/entries/x-viral.json
+++ b/entries/x-viral.json
@@ -1,0 +1,30 @@
+{
+  "id": "x-viral",
+  "displayName": "X Viral",
+  "description": "Scores a draft X post against the open-source For You ranking weights, then runs an autoresearch loop that applies every edit that raises the score, checks dropped images and videos for the feed, and drafts a video script.",
+  "icon": {
+    "url": "./icons/x-viral-94c4279d.svg"
+  },
+  "tags": [
+    "x",
+    "twitter",
+    "social-media",
+    "writing",
+    "scoring",
+    "autoresearch",
+    "video",
+    "images"
+  ],
+  "author": {
+    "name": "Jing Reyhan",
+    "github": "j1ngg",
+    "url": "https://github.com/j1ngg"
+  },
+  "category": "utilities",
+  "source": {
+    "git": {
+      "url": "https://github.com/j1ngg/bb-plugin-x-viral.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/icons/x-viral-94c4279d.svg
+++ b/icons/x-viral-94c4279d.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 17l6-6 4 4 8-8"/><path d="M14 7h7v7"/></svg>


### PR DESCRIPTION
## What it does

X Viral scores a draft X post against the ranking weights published in xai-org/x-algorithm (weighted engagement heads, out-of-network discount, visibility gates), then runs an autoresearch loop: it tries each candidate edit, rescores, and keeps only edits that raise the score. It lists the content levers that would move the post further with projected scores, checks a dropped image or video for feed display and the 10-second video threshold, drafts a video beat sheet from the post's own sentences, and can hand the rewrite brief to a bb agent thread.

Surfaces: sidebar page "X Viral", CLI `bb x-viral score|autoresearch|video|weights`, agent tools `x_viral_score`, `x_viral_autoresearch`, `x_viral_video_script`, and the `x-viral-autoresearch` skill.

## Release source

- `https://github.com/j1ngg/bb-plugin-x-viral.git`, range `^0.1.0` (tag `v0.1.0`)
- Plugin id `x-viral`, package `bb-plugin-x-viral@0.1.0`, MIT

## Plugin checks

- `npm test`: 32 tests passing (vitest, `@get-bb/plugin-sdk/testing` fake host)
- `npm run typecheck`: clean
- `bb plugin build`: server and app bundles built against SDK 0.4.34

## Marketplace checks

- `npm run build`, `npm run gate:v1`, `npm test`: passing
- `npm run check`: passes once the release tag is public

## Permissions and security

- No settings, secrets, network calls, or background services. All scoring runs in the plugin server from post text and optional context flags.
- Media checks read file metadata in the browser only; nothing is uploaded.
- The agent hand-off opens a new thread via `useBbNavigate().toCompose` with a prefilled prompt; it does not create threads on its own.
