### PR TITLE
Add plugin entry: chief

### DIFF
--- a/entries/chief.json
+++ b/entries/chief.json
@@ -1,0 +1,25 @@
+{
+  "id": "chief",
+  "displayName": "Chief",
+  "description": "Coordinates project supervisors that delegate work to managed worker and reviewer threads and follow it through completion.",
+  "icon": "Crown",
+  "tags": [
+    "agents",
+    "delegation",
+    "supervision",
+    "threads",
+    "workflows"
+  ],
+  "author": {
+    "name": "Divyesh",
+    "github": "divyesh-puri",
+    "url": "https://github.com/divyesh-puri"
+  },
+  "category": "tasks-and-workflows",
+  "source": {
+    "git": {
+      "url": "https://github.com/divyesh-puri/bb-plugin-chief.git",
+      "range": "^0.1.0"
+    }
+  }
+}


### PR DESCRIPTION
## What this adds

Chief coordinates project-scoped supervisor threads that delegate implementation to managed-worktree workers, request independent reviews, inspect evidence, and follow work through verified completion. Chiefs, workers, and reviewers remain ordinary visible BB threads in a native Chief section.

The New Thread screen can create multiple independent Chiefs per project, and Chief conversations receive a compact header badge.

## Release source

- Repository: https://github.com/divyesh-puri/bb-plugin-chief
- Release: `v0.1.0`
- Marketplace range: `^0.1.0`
- Plugin ID: `chief`

## Validation

Plugin release:

- 21 Vitest tests passed
- TypeScript check passed
- `bb plugin types --check` passed against SDK `0.4.34`
- `bb plugin build` passed
- Public tag resolves to commit `64ac8bc3613efbdd5841af0487b31e9003ed5efe`

Marketplace:

- `npm run build` passed
- 35 marketplace tests passed
- `npm run gate:v1` passed
- `npm run check` including source liveness passed
- `git diff --check` passed

## Permissions and security

- No external service or credential is required.
- The plugin reads optional project-root `chief.md` instructions.
- It creates and updates BB threads, creates managed worktrees for delegated workers, reuses worker environments for reviewers, and sends lifecycle messages between managed threads.
- Plugin lifecycle state and alert retries are stored in the plugin's local SQLite database.
- It does not perform production data mutations or communicate with third-party services.
