### PR TITLE
Add plugin entry: app-preview

### DIFF
--- a/entries/app-preview.json
+++ b/entries/app-preview.json
@@ -16,7 +16,7 @@
     "github": "hungv47",
     "url": "https://github.com/hungv47"
   },
-  "category": "thread-content",
+  "category": "utilities",
   "source": {
     "git": {
       "url": "https://github.com/hungv47/bb-plugin-app-preview.git",

--- a/entries/app-preview.json
+++ b/entries/app-preview.json
@@ -1,0 +1,26 @@
+{
+  "id": "app-preview",
+  "displayName": "App Preview",
+  "description": "Detects the app in a thread worktree, starts it in a BB terminal, and opens it in the in-app browser.",
+  "icon": "Play",
+  "tags": [
+    "preview",
+    "dev-server",
+    "worktree",
+    "browser",
+    "interface",
+    "developer-tools"
+  ],
+  "author": {
+    "name": "Hung Vinh",
+    "github": "hungv47",
+    "url": "https://github.com/hungv47"
+  },
+  "category": "thread-content",
+  "source": {
+    "git": {
+      "url": "https://github.com/hungv47/bb-plugin-app-preview.git",
+      "range": "^0.1.0"
+    }
+  }
+}

--- a/entries/app-preview.json
+++ b/entries/app-preview.json
@@ -1,8 +1,9 @@
 {
   "id": "app-preview",
   "displayName": "App Preview",
-  "description": "Detects the app in a thread worktree, starts it in a BB terminal, and opens it in the in-app browser.",
+  "description": "Detects the app in a thread worktree, starts the detected recipe in a BB terminal, and can open it in the in-app browser. Ports can share a listener over BB Connect or send SIGTERM/SIGKILL.",
   "icon": "Play",
+  "overview": "./overview/app-preview.md",
   "tags": [
     "preview",
     "dev-server",
@@ -20,7 +21,7 @@
   "source": {
     "git": {
       "url": "https://github.com/hungv47/bb-plugin-app-preview.git",
-      "range": "^0.1.0"
+      "range": "^0.2.9"
     }
   }
 }

--- a/overview/app-preview.md
+++ b/overview/app-preview.md
@@ -1,0 +1,37 @@
+App Preview finds startable apps in the current thread worktree, runs the
+detected recipe in a BB terminal, and can open the result in the in-app
+browser. A Ports list can share a listener over BB Connect or signal it.
+
+## Trust and machine effects
+
+This is a full-trust plugin. After you install it:
+
+- **Dependency installation.** Start can run the detected package manager
+  install (`npm` / `pnpm` / `yarn` / `bun` / `uv` / `pip` / `bundle` /
+  `composer`) when that setting is on.
+- **Repository-script execution.** Start runs the detected dev/start recipe
+  from the worktree in a BB terminal. Agents can only start that detected
+  recipe. They cannot pass an arbitrary command. The Preview panel and
+  `bb preview start --command` may override with a plain argv (no
+  substitutions, quotes, or shell operators).
+- **Process signaling.** Ports can send SIGTERM or SIGKILL to a listener by
+  port or PID. Agent share, unshare, and kill wait for an in-app confirmation
+  that echoes a plugin-issued token. The Ports panel still asks before kill.
+- **BB Connect exposure.** Share publishes a listening port as
+  `https://<handle>--<port>.getbb.app`. That URL is reachable from other
+  machines and phones while the share exists.
+
+Preview state lives in the plugin SQLite database. It does not call a
+third-party API or store credentials.
+
+## Launch safety (0.2.9)
+
+Start is a working directory plus argv recipe. The worktree path is not
+interpolated into the shell command string. Nested apps `cd -- ./dir` so
+`CDPATH` cannot redirect them.
+
+## Install
+
+```
+bb plugin install git:github.com/hungv47/bb-plugin-app-preview@semver:^0.2.9
+```


### PR DESCRIPTION
Detects the app in a thread worktree, starts the detected recipe in a BB terminal, and can open it in the in-app browser. Ports can share a listener over BB Connect or send SIGTERM/SIGKILL.

## Source

- Git: https://github.com/hungv47/bb-plugin-app-preview.git
- Range: `^0.2.9`
- Tag: `v0.2.9` (peel `21de6996301f82836def0bd444dcd310b46def01`)
- Plugin id: `app-preview`
- Package: `bb-plugin-app-preview@0.2.9`
- Overview: `overview/app-preview.md`

## Plugin checks (0.2.9)

- Launch is a working directory plus argv recipe. Nested `cd` uses `./` so `CDPATH` cannot redirect it.
- Agent `preview_app` cannot pass `command`. Share, unshare, and kill wait for a BB confirmation that echoes a plugin-issued token.
- Overview discloses dependency installation, repository-script execution, process signaling, and BB Connect.

## Permissions and security

This is a normal full-trust BB plugin. After install it can run the detected package-manager install, start the detected recipe, share a listening port over BB Connect, and signal a listener. Preview state lives in the plugin SQLite database. It does not call a third-party API or store credentials.

Install:

```
bb plugin install git:github.com/hungv47/bb-plugin-app-preview@semver:^0.2.9
```