### PR TITLE
Add plugin entry: auto-compact

### DIFF
--- a/entries/auto-compact.json
+++ b/entries/auto-compact.json
@@ -1,0 +1,19 @@
+{
+  "id": "auto-compact",
+  "displayName": "Auto Compact",
+  "description": "Compacts thread context automatically once usage reaches a configurable percentage, with a manual Compact button in every thread header.",
+  "icon": "Minimize2",
+  "tags": ["context", "compaction", "threads", "automation", "tokens"],
+  "author": {
+    "name": "Dummy-pixel-hash",
+    "github": "Dummy-pixel-hash",
+    "url": "https://github.com/Dummy-pixel-hash/bb-plugin-auto-compact"
+  },
+  "category": "token-usage-and-limits",
+  "source": {
+    "git": {
+      "url": "https://github.com/Dummy-pixel-hash/bb-plugin-auto-compact.git",
+      "range": "^0.1.0"
+    }
+  }
+}


### PR DESCRIPTION
# Add plugin entry: auto-compact

## What the plugin does

Auto Compact watches per-thread context-window usage and compacts a thread
automatically once usage reaches a configurable percentage (default 80%,
selectable 70–95). It acts only on idle/failed threads — the states where BB
allows compaction — with a 15-minute per-thread cooldown, plus:

- a Compact button in every thread header with live usage readout and spinner,
- a `bb auto-compact` CLI (`status`, `check`, `now`),
- graceful `unsupported` reporting on providers that cannot compact (e.g.
  some ACP bridges), staying quiet instead of retrying every idle event.

## Release source

- Git range `^0.1.0` over
  `https://github.com/Dummy-pixel-hash/bb-plugin-auto-compact.git`
- Tag `v0.1.0` published and verified via `git ls-remote --tags`.
- MIT licensed public repository.

## Plugin checks passed

- `npx tsc --noEmit` — clean
- `npx vitest run` — 18/18 pass (threshold, cooldown, disabled state, failed
  threads, unsupported providers, `usage`/`compact_now` RPCs, CLI)
- `bb plugin build` — emits `dist/server.*` + `dist/app.*`
- `bb plugin install` — `running`, live `check` verified on a real thread

## Marketplace checks passed

- `npm run build` — 123 entries built (v1 + v2)
- `npm run check` (liveness over the public git source) — pass
- `npm test` — pass
- `npm run gate:v1` — pass (1 new entry, no exception needed)
- Commit contains only `entries/auto-compact.json`; `git diff --check` clean

## Permissions, external services, security

- No network calls, no external services, no credentials or secrets.
- Reads thread timeline usage, calls `threads.compact` on idle/failed
  threads only; per-thread cooldown/unsupported timestamps in plugin KV.
- No user data leaves the BB host.
