### PR TITLE
file-manager 0.8.0: open a file in the manager itself, and an Open item in the row menu

### DIFF
--- a/entries/file-manager.json
+++ b/entries/file-manager.json
@@ -1,7 +1,7 @@
 {
   "id": "file-manager",
   "displayName": "File Manager",
-  "description": "Browse, upload, download, move, rename and extract files under your home folder — as a full-page bb panel, as a tab in the side panel beside a thread, or straight from a message: right-click a file link and \"File location\" opens its folder with the file selected. Space previews the focused file, a gallery view shows thumbnails, Properties answers what a file or folder actually is, bookmarks keep the folders you live in one click away, and a file can be handed to the agent as an @-mention — including from the composer's + menu, which otherwise only reaches the browser's machine. Multi-gigabyte uploads resume after a dropped connection.",
+  "description": "Browse, upload, download, move, rename and extract files under your home folder — as a full-page bb panel, as a tab in the side panel beside a thread, or straight from a message: right-click a file link and \"File location\" opens its folder with the file selected. Double-click or Enter opens a file to read it: beside a thread it goes to bb's own preview panel, and on the full page the manager shows it itself — images, PDF, video and audio play in place, Markdown is rendered, and everything else opens with syntax highlighting. Space quick-looks the focused row, a gallery view shows thumbnails, Properties answers what a file or folder actually is, bookmarks keep the folders you live in one click away, and a file can be handed to the agent as an @-mention — including from the composer's + menu, which otherwise only reaches the browser's machine. Multi-gigabyte uploads resume after a dropped connection.",
   "icon": "FolderOpen",
   "tags": [
     "files",
@@ -21,7 +21,7 @@
     "git": {
       "url": "https://github.com/xMinor-1/bb-plugins.git",
       "subdir": "plugins/file-manager",
-      "range": "^0.7.0",
+      "range": "^0.8.0",
       "tagPrefix": "file-manager/"
     }
   }


### PR DESCRIPTION
Updates the existing `file-manager` entry ([PR #90](https://github.com/get-bb/marketplace/pull/90), last widened in [PR #122](https://github.com/get-bb/marketplace/pull/122)) for the 0.8.x line. Code lives in the same repository and subdirectory; only the range and the description change.

**Why the range has to move.** The entry declares `^0.7.0`, which on a `0.x` line covers `0.7.x` only, so `file-manager/v0.8.0` never reaches the catalog. Widened to `^0.8.0`.

**What the plugin gained in 0.8.0**

- **A file opens in the manager itself on the full page.** Double-click used to hand the file to bb's preview panel, which bb only offers beside a thread and in the side-panel tab. On the standalone File Manager page the answer was always no, and the file silently went to downloads instead. Now that surface shows the file itself: images, PDF, video and audio play in place, Markdown is rendered with the source one click away, and everything else opens in bb's source viewer with syntax highlighting. Beside a thread the file still goes to bb's own panel, which is the better home for it.
- **Files with no extension open too** — `Makefile`, `LICENSE`, `.gitignore`. Text or not is decided on the server from the bytes, not from the name; anything that turns out not to be text says so and offers the download.
- **An "Open" item in the row context menu.** It previously existed for folders only, so for a file the action lived in the double-click alone.

Path resolution stays inside the plugin's hard root (the home directory of the user running bb), through the same clamp every other operation uses.

Verified locally: `npm ci --ignore-scripts && npm run build && npm run check` (the liveness check resolves the range against the real `file-manager/v0.8.0` tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)