### PR TITLE
Update Linear and Xcode release ranges

### DIFF
--- a/entries/linear.json
+++ b/entries/linear.json
@@ -25,7 +25,7 @@
   "source": {
     "git": {
       "url": "https://github.com/vburojevic/bb-plugin-linear.git",
-      "range": "^0.1.3"
+      "range": "^0.5.0"
     }
   }
 }

--- a/entries/xcode.json
+++ b/entries/xcode.json
@@ -26,7 +26,7 @@
   "source": {
     "git": {
       "url": "https://github.com/vburojevic/bb-plugin-xcode.git",
-      "range": "^0.2.0"
+      "range": "^0.3.1"
     }
   }
 }


### PR DESCRIPTION
The current marketplace ranges exclude the published Linear 0.5 and Xcode 0.3 releases. Update Linear to `^0.5.0` and Xcode to `^0.3.1` so installs can select them and receive compatible patches.

Linear remains the local issue mirror and thread integration. Xcode 0.3.1 includes coalesced simulator discovery, tracked-build host validation, and SDK updates. These entries retain their existing repository owners, descriptions, icons, categories, and service requirements.

Validation: both plugin typechecks and automated suites pass; Xcode's release build passes. Both public tags were verified against their release commits. Marketplace `npm run build`, `npm test`, and `npm run check` pass.

`npm run gate:v1` correctly reports these two intentional range changes. A maintainer must apply the `v1-change` label to approve the frozen-v1 update; this contributor account cannot apply repository labels.

Release sources:
- https://github.com/vburojevic/bb-plugin-linear/releases/tag/v0.5.0
- https://github.com/vburojevic/bb-plugin-xcode/releases/tag/v0.3.1
