### PR TITLE
Add plugin entry: cf-tunnel

### DIFF
--- a/entries/cf-tunnel.json
+++ b/entries/cf-tunnel.json
@@ -1,0 +1,25 @@
+{
+  "id": "cf-tunnel",
+  "displayName": "Cloudflare Tunnel",
+  "description": "Reach bb from anywhere over your own Cloudflare Tunnel and Access policy, replacing bb connect.",
+  "icon": "Cloud",
+  "tags": [
+    "cloudflare",
+    "cloudflare-tunnel",
+    "remote-access",
+    "tunnel",
+    "security"
+  ],
+  "author": {
+    "name": "MGrin",
+    "github": "MGrin",
+    "url": "https://github.com/MGrin"
+  },
+  "category": "cloud-and-remote",
+  "source": {
+    "git": {
+      "url": "https://github.com/MGrin/bb-plugin-cf-tunnel.git",
+      "ref": "8f90f1067463f8f9682658550daf892fc881aed4"
+    }
+  }
+}


### PR DESCRIPTION
Adds a marketplace entry for `bb-plugin-cf-tunnel`.

**What it does:** reaches a bb instance from anywhere over your own Cloudflare
Tunnel and Access policy, as an alternative to `bb connect` that doesn't route
remote traffic through third-party relay infrastructure.

**Release source:** public Git repo `MGrin/bb-plugin-cf-tunnel`, MIT licensed.
The repository has no tagged releases yet, so this entry pins an exact commit
(`8f90f10`, current `main` HEAD) rather than a semver range. A tagged release
can follow in a later PR once one exists.

**Plugin checks:** package.json declares `bb.name`, `bb.description`,
`bb.branding.icon` and `engines`; derived plugin ID (`cf-tunnel`) matches this
entry's ID and filename.

**Marketplace checks:** `npm run build`, `npm test`, `npm run gate:v1`, and
`npm run check` (source liveness) all pass on this branch.

**Permissions / security:** runs a WebSocket connection to a Cloudflare Tunnel
the user configures with their own account and domain; no third-party relay.
No external services beyond Cloudflare, which the user owns.
