### PR TITLE
Add plugin entry: bus

### DIFF
--- a/entries/bus.json
+++ b/entries/bus.json
@@ -1,0 +1,25 @@
+{
+  "id": "bus",
+  "displayName": "Bus",
+  "description": "Peer session bus between bb threads: rooms, presence, ambient messages, and addressed sends that wake the recipient.",
+  "icon": "Radio",
+  "tags": [
+    "threads",
+    "messaging",
+    "coordination",
+    "multi-agent",
+    "agent-tools"
+  ],
+  "author": {
+    "name": "MGrin",
+    "github": "MGrin",
+    "url": "https://github.com/MGrin"
+  },
+  "category": "agents-and-providers",
+  "source": {
+    "git": {
+      "url": "https://github.com/MGrin/bb-plugin-bus.git",
+      "ref": "8c945cfc95e638bf1226d7705c658a361e5d70e8"
+    }
+  }
+}


### PR DESCRIPTION
Adds a marketplace entry for `bb-plugin-bus`.

**What it does:** a peer session bus between bb threads — rooms, presence,
ambient messages, and addressed sends that wake the recipient thread with a
real turn, so a thread can never silently go deaf to a message.

**Release source:** public Git repo `MGrin/bb-plugin-bus`, MIT licensed.
The repository has no tagged releases yet, so this entry pins an exact commit
(`8c945cf`, current `main` HEAD) rather than a semver range. A tagged release
can follow in a later PR once one exists.

**Plugin checks:** package.json declares `bb.name`, `bb.description`,
`bb.branding.icon` and `engines`; derived plugin ID (`bus`) matches this
entry's ID and filename.

**Marketplace checks:** `npm run build`, `npm test`, `npm run gate:v1`, and
`npm run check` (source liveness) all pass on this branch.

**Permissions / security:** runs entirely inside the bb server; no external
network calls or third-party services.
