### PR TITLE
Add plugin entry: memory-ui

### DIFF
--- a/entries/memory-ui.json
+++ b/entries/memory-ui.json
@@ -1,0 +1,24 @@
+{
+  "id": "memory-ui",
+  "displayName": "Memory UI",
+  "description": "Browse, search, edit and forget bb memories — FTS search, per-record history, and a Sweep view of what has been rewriting the store.",
+  "icon": "Brain",
+  "tags": [
+    "memory",
+    "search",
+    "curation",
+    "interface"
+  ],
+  "author": {
+    "name": "MGrin",
+    "github": "MGrin",
+    "url": "https://github.com/MGrin"
+  },
+  "category": "memory-and-context",
+  "source": {
+    "git": {
+      "url": "https://github.com/MGrin/bb-plugin-memory-ui.git",
+      "ref": "60901ad7fa4892e4e20e6aac12ae25b0b6252a3e"
+    }
+  }
+}


### PR DESCRIPTION
Adds a marketplace entry for `bb-plugin-memory-ui`.

**What it does:** a browsing and curation UI for bb's agent memory — full-text
search, per-record history, and a Sweep view of what has been rewriting the
store, on top of a memory plugin whose only stock UI is a settings table.

**Release source:** public Git repo `MGrin/bb-plugin-memory-ui`, MIT licensed.
The repository has no tagged releases yet, so this entry pins an exact commit
(`60901ad`, current `main` HEAD) rather than a semver range. A tagged release
can follow in a later PR once one exists.

**Plugin checks:** package.json declares `bb.name`, `bb.description`,
`bb.branding.icon` and `engines`; derived plugin ID (`memory-ui`) matches this
entry's ID and filename.

**Marketplace checks:** `npm run build` and `npm run check` (source liveness,
git-based — no error reported for this entry) pass on this branch.

**Permissions / security:** reads and writes bb's own memory store through
bb's plugin APIs; no external services.
