### PR TITLE
Update provider-usage: widen range so installs get a current build

### DIFF
--- a/entries/provider-usage.json
+++ b/entries/provider-usage.json
@@ -1,7 +1,7 @@
 {
   "id": "provider-usage",
   "displayName": "Provider Usage",
-  "description": "Shows how much of each provider's plan is left — every rate-limit window, percent remaining, and when it resets — plus a 7/30/90-day token chart covering every provider, from local transcripts and BB's own usage events.",
+  "description": "Shows how much of each provider's plan is left \u2014 every rate-limit window, percent remaining, and when it resets \u2014 plus a 7/30/90-day token chart covering every provider, from local transcripts and BB's own usage events.",
   "icon": {
     "url": "./icons/provider-usage-752e444b.svg"
   },
@@ -25,7 +25,7 @@
   "source": {
     "git": {
       "url": "https://github.com/braedonsaunders/bb-plugin-provider-usage.git",
-      "range": "^0.4.0"
+      "range": ">=0.4.0 <1.0.0"
     }
   }
 }


### PR DESCRIPTION
The `provider-usage` entry has tracked `^0.4.0` since it was added. That resolves to **v0.4.0 exactly** — the only tag in the 0.4.x line. The plugin is at **v0.10.0**, so every marketplace install has been getting a build six minor versions old.

What a v0.4.0 install is missing, all shipped since:

- Codex credit accounting, banked resets, and the extra rate-limit buckets
- The Claude usage-meter backoff — v0.4.0 polls Anthropic's `oauth/usage` often enough to get 429'd
- Live token throughput with native BB event attribution
- Spend controls and visible per-provider costs
- The cached-token accounting fix, without which canonical totals are wrong

Widened to `>=0.4.0 <1.0.0`, matching the pattern already accepted on other entries in this repo, so future 0.x releases are picked up without an entry change each time. Nothing else in the entry changes — same id, icon, description, category and author.

`node scripts/build.mjs` passes: 144 entries, no new warnings.

Source: https://github.com/braedonsaunders/bb-plugin-provider-usage (v0.10.0 tagged)