### PR TITLE
Update plugin entry: files-editor

### DIFF
--- a/entries/files-editor.json
+++ b/entries/files-editor.json
@@ -1,16 +1,20 @@
 {
   "id": "files-editor",
   "displayName": "Files",
-  "description": "Browse and edit the workspace behind a thread in an editor layout: a searchable file tree on the left, tabs across the top, and the whole file in the middle. Opens as a full-page panel or as a tab beside a thread, where it is pinned to that thread's worktree so it shows the files the agent is editing. Cmd+P ranks files by path; clicking one opens it in its own tab, syntax-highlighted in your BB code theme. Saves are guarded by the hash the file had when it was opened, so an edit an agent made underneath you stops the save and offers Reload or Overwrite. For a workspace on the machine BB runs on it walks the directory itself, so dotfiles appear. Adds a `bb files` command that gives agents the same listing, which reads the right disk when the workspace is on another machine.",
+  "description": "A VS Code-style file explorer and editor for the workspace behind a thread. A searchable file tree on the left, editor tabs across the top, and the whole file in the middle \u2014 as a full-page panel, or as a tab beside a thread where it is pinned to that thread's worktree so it shows the files the agent is editing. Cmd+P is a fuzzy go-to-file palette; Cmd+F finds text inside the open file with a match count and case matching. Files open syntax-highlighted in your BB code theme, and can be edited and saved: a save is guarded by the hash the file had when it was opened, so a change an agent made underneath you stops it and offers Reload or Overwrite rather than clobbering the change. Two dependent pickers choose the project and then its checkout or one of its worktrees by branch name. Dotfiles appear for a workspace on the machine BB runs on, because it walks the directory itself instead of using BB's listing, which drops them. Adds a `bb files` command so agents can browse, search and read the same workspace from the CLI \u2014 which reads the right disk when that workspace is on another machine.",
   "icon": {
     "url": "./icons/files-editor-43529076.svg"
   },
   "tags": [
     "files",
-    "editor",
     "file-explorer",
-    "code",
-    "interface",
+    "file-browser",
+    "file-tree",
+    "editor",
+    "code-editor",
+    "text-editor",
+    "vscode",
+    "workspace",
     "developer-tools"
   ],
   "author": {


### PR DESCRIPTION
Updates the `files-editor` listing so it can be found. No source, name, owner or icon change — the entry still tracks `^0.1.2` over the same repository's tags.

## Adds a category

`files-editor` was the only one of 153 entries with no `category`, so it shows blank in the store's Category column and is missing from that filter entirely. Set to `file-viewers-and-editors`, alongside the other preview and editor plugins.

## Describes it in the words people search for

The old description opened with "Browse and edit the workspace behind a thread in an editor layout". Someone looking for a *file explorer*, a *file tree*, *editor tabs*, *syntax highlighting* or *find in file* had little to match on. The new one names those directly, and adds the two features shipped since the listing was reviewed:

- **Find in file** — `Cmd+F` inside the open file, with a match count and case matching
- **Project and worktree pickers** — two dependent controls, project then its checkout or one of its worktrees by branch name

Everything it claims is implemented and released; the tags avoid `file-manager`, since this tree deliberately does not create, rename or delete files.

## Tags

`files`, `file-explorer`, `file-browser`, `file-tree`, `editor`, `code-editor`, `text-editor`, `vscode`, `workspace`, `developer-tools`

## Checks

`npm ci --ignore-scripts`, `npm run build` and `npm run check` all pass — 153 entries composed, and the liveness check resolves the git source. The remaining `1 unchanged entry file has no category` warning is a different entry, not this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
