### PR TITLE
Point hmm-floating-terminal at its renamed repository

### DIFF
--- a/entries/hmm-floating-terminal.json
+++ b/entries/hmm-floating-terminal.json
@@ -25,7 +25,7 @@
   "category": "command-line",
   "source": {
     "git": {
-      "url": "https://github.com/fadlihdytullah/hmm-floating-terminal.git",
+      "url": "https://github.com/fadlihdytullah/bb-plugin-hmm-floating-terminal.git",
       "range": "^0.3.0"
     }
   },


### PR DESCRIPTION
The plugin repository was renamed from `hmm-floating-terminal` to
`bb-plugin-hmm-floating-terminal` so it matches the package name in
`package.json`. This updates `source.git.url` in the entry to the new address.

Nothing else changes: the entry ID stays `hmm-floating-terminal`, because that
is what BB derives from the package name (`bb-plugin-` prefix stripped), and
the ID has to keep matching the plugin manifest. The version range is
untouched.

GitHub redirects the old URL, so the current entry still resolves — this is
housekeeping so the entry points where the tags actually live.

Checks run locally: `npm run build` (153 entries, no new warnings) and
`git ls-remote` against the renamed repository, which resolves `v0.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)