### PR TITLE
Update sql entry to ^0.3.0

### DIFF
--- a/entries/sql.json
+++ b/entries/sql.json
@@ -1,8 +1,8 @@
 {
   "id": "sql",
   "displayName": "SQL",
-  "description": "Browse Postgres schemas and run read-only SQL from a bb panel or agent tools; write support is planned for 0.5.",
-  "icon": "Database",
+  "description": "Browse Postgres schemas and run read-only SQL from a bb panel or agent tools (v0.3: secrets file passwords, URI paste, SSL PEM paths). Write support is planned for 0.5.",
+  "icon": "Layers",
   "tags": [
     "sql",
     "postgres",
@@ -20,7 +20,7 @@
   "source": {
     "git": {
       "url": "https://github.com/yazydzhi/bb-plugin-sql.git",
-      "range": "^0.2.0"
+      "range": "^0.3.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Bump `sql` marketplace range from `^0.2.0` → `^0.3.0` (release tag `v0.3.0`)
- Icon `Database` → `Layers` (matches plugin branding)
- Description notes v0.3 credential/URI/SSL hardening

## Source
- https://github.com/yazydzhi/bb-plugin-sql/releases/tag/v0.3.0

## Checks
- `npm run build`
- `npm run check` (liveness)

Made with [Cursor](https://cursor.com)