### PR TITLE
Update sql entry to ^0.5.4

### DIFF
--- a/entries/sql.json
+++ b/entries/sql.json
@@ -1,15 +1,14 @@
 {
   "id": "sql",
   "displayName": "SQL",
-  "description": "Browse Postgres schemas and run read-only SQL from a bb panel or agent tools; write support is planned for 0.5.",
-  "icon": "Database",
+  "description": "Browse Postgres schemas and run SQL from a bb panel or agent tools. Controlled write/DDL (0.5): Agent write and Allow DDL off by default.",
+  "icon": "Layers",
   "tags": [
     "sql",
     "postgres",
     "database",
     "developer-tools",
-    "query",
-    "read-only"
+    "query"
   ],
   "author": {
     "name": "yazydzhi",
@@ -20,7 +19,7 @@
   "source": {
     "git": {
       "url": "https://github.com/yazydzhi/bb-plugin-sql.git",
-      "range": "^0.2.0"
+      "range": "^0.5.4"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Bump `sql` install range from `^0.2.0` → `^0.5.4` ([bb-plugin-sql](https://github.com/yazydzhi/bb-plugin-sql) tag `v0.5.4`)
- Description: controlled write/DDL — Agent write and Allow DDL off by default
- Icon `Layers`; drop `read-only` tag

Supersedes the earlier `^0.4.1` wording on this branch.

## Test plan
- [ ] `bb plugin install sql` resolves `>=0.5.4 <0.6.0`
- [ ] Entry validates against marketplace schema / CI
- [ ] Needs **`v1-change`** label (frozen v1 entry) — maintainers please add
- [ ] Description and icon render in the store UI