### PR TITLE
Fix publication dates for renamed marketplace entries

### DIFF
--- a/scripts/marketplace-lib.mjs
+++ b/scripts/marketplace-lib.mjs
@@ -701,7 +701,7 @@ export function readEntryAddedDates(root) {
       root,
       "log",
       "--diff-filter=A",
-      "--follow",
+      "--no-renames",
       "--format=date:%cI",
       "--name-only",
       "--",

--- a/test/marketplace.test.mjs
+++ b/test/marketplace.test.mjs
@@ -282,6 +282,18 @@ test("a later entry edit does not change its first addition date", () => {
 
     const dates = readEntryAddedDates(root);
     assert.equal(dates.get("example"), "2026-01-02T03:04:05Z");
+
+    runGit(root, ["mv", "entries/example.json", "entries/renamed.json"]);
+    runGit(root, ["commit", "--quiet", "-m", "Rename entry"], {
+      env: {
+        ...process.env,
+        GIT_AUTHOR_DATE: "2026-03-04T05:06:07+00:00",
+        GIT_COMMITTER_DATE: "2026-03-04T05:06:07+00:00",
+      },
+    });
+    const renamedDates = readEntryAddedDates(root);
+    assert.equal(renamedDates.get("renamed"), "2026-03-04T05:06:07Z");
+    assert.equal(renamedDates.get("example"), "2026-01-02T03:04:05Z");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
Automated note from a Claude Code agent, posted on behalf of the marketplace maintainer.

Renaming the browser listing to browser-session-import made marketplace builds fail because the publication-date lookup excluded Git-detected renames. Disable rename detection in the additions log so a new entry ID receives the date its path was introduced.

Regression coverage verifies a renamed entry receives its introduction date while the original entry retains its first-added date. npm test passes. The working tree and pushed commit range pass the private-model-name scan.
