### PR TITLE
Note that Browser Copy's header button is desktop-only

### DIFF
--- a/overview/browser-copy.md
+++ b/overview/browser-copy.md
@@ -58,7 +58,9 @@ screen, so an image of a secret field is possible. Pick deliberately.
 ## Requirements
 
 - BB desktop with the native Browser and Plugin SDK 0.4.48 or newer. The plugin needs
-  `experimental_desktopBrowsers` to attach to a tab.
+  `experimental_desktopBrowsers` to attach to a tab. The header button appears only in the
+  desktop app: picking an element means clicking it in the native Browser view, which a
+  browser client cannot do, so the control is not offered on the web client.
 - A Browser tab open in the thread you are copying from. With none open, the modes are
   disabled and the dropdown says so; it re-checks the thread's tabs every time you open it,
   so open the tab and reopen the menu.


### PR DESCRIPTION
Follow-up to #241, merged. **Docs only** — no entry fields change, so this needs no `v1-change` label; the source range stays `^0.2.2`, which already covers 0.2.3.

The plugin's header button rendered on the **web client** too, where the feature cannot be used: picking an element means clicking it in a native Browser view, which a browser client cannot see or click. Clicking it there acquired a lease and armed a picker nobody could answer.

`GantisStorm/bb-plugin-browser-copy@v0.2.3` skips registering the action when `window.bbDesktop` is absent — the global the desktop shell exposes through `contextBridge.exposeInMainWorld` before any page script runs, and the same signal bb's own desktop-only UI reads via `getBbDesktopInfo`. The plugin SDK has no platform surface for this yet, so the read is typed with a small `Window` augmentation rather than a cast.

**Verification**
- Web client (no `bbDesktop`): the header action and its `role="group"` are absent; the neighbouring header controls are untouched.
- Desktop: the global is exposed unconditionally at `apps/desktop/src/preload.ts:560`, before renderer scripts, so registration proceeds exactly as before.

This syncs `overview/browser-copy.md` from the plugin repository, where the Requirements section now states the button appears only in the desktop app. `npm run build` → 170 entries; `npm run test` → 35/35; `npm run gate:v1` passes with the note that no new entries need an exception.
