### PR TITLE
Move Sawyer Hood's plugins to the sawyer-plugins monorepo

### DIFF
--- a/entries/cascade.json
+++ b/entries/cascade.json
@@ -13,7 +13,9 @@
   "category": "thread-management",
   "source": {
     "git": {
-      "url": "https://github.com/SawyerHood/bb-plugin-cascade.git",
+      "url": "https://github.com/SawyerHood/sawyer-plugins.git",
+      "subdir": "plugins/cascade",
+      "tagPrefix": "cascade/",
       "range": "^0.1.0"
     }
   }

--- a/entries/compact-nav.json
+++ b/entries/compact-nav.json
@@ -24,7 +24,9 @@
   "category": "themes-and-appearance",
   "source": {
     "git": {
-      "url": "https://github.com/SawyerHood/bb-plugin-compact-nav.git",
+      "url": "https://github.com/SawyerHood/sawyer-plugins.git",
+      "subdir": "plugins/compact-nav",
+      "tagPrefix": "compact-nav/",
       "range": "^0.1.0"
     }
   }

--- a/entries/miku.json
+++ b/entries/miku.json
@@ -11,7 +11,9 @@
   },
   "source": {
     "git": {
-      "url": "https://github.com/SawyerHood/bb-plugin-miku.git",
+      "url": "https://github.com/SawyerHood/sawyer-plugins.git",
+      "subdir": "plugins/miku",
+      "tagPrefix": "miku/",
       "range": "^0.6.0"
     }
   },

--- a/entries/slopcop.json
+++ b/entries/slopcop.json
@@ -17,7 +17,9 @@
   "category": "code-and-reviews",
   "source": {
     "git": {
-      "url": "https://github.com/SawyerHood/bb-slop-cop.git",
+      "url": "https://github.com/SawyerHood/sawyer-plugins.git",
+      "subdir": "plugins/slopcop",
+      "tagPrefix": "slopcop/",
       "range": "^0.1.0"
     }
   }

--- a/entries/t3sidebar.json
+++ b/entries/t3sidebar.json
@@ -11,7 +11,9 @@
   "category": "thread-management",
   "source": {
     "git": {
-      "url": "https://github.com/SawyerHood/bb-plugin-t3sidebar.git",
+      "url": "https://github.com/SawyerHood/sawyer-plugins.git",
+      "subdir": "plugins/t3sidebar",
+      "tagPrefix": "t3sidebar/",
       "range": "^0.1.0"
     }
   }


### PR DESCRIPTION
## Summary

Moves my published plugins to a single monorepo, https://github.com/SawyerHood/sawyer-plugins, using the `subdir` and `tagPrefix` source fields.

| Entry | Old source | New source |
| --- | --- | --- |
| cascade | SawyerHood/bb-plugin-cascade | sawyer-plugins, `plugins/cascade`, tags `cascade/vX.Y.Z` |
| compact-nav | SawyerHood/bb-plugin-compact-nav | sawyer-plugins, `plugins/compact-nav`, tags `compact-nav/vX.Y.Z` |
| miku | SawyerHood/bb-plugin-miku | sawyer-plugins, `plugins/miku`, tags `miku/vX.Y.Z` |
| slopcop | SawyerHood/bb-slop-cop | sawyer-plugins, `plugins/slopcop`, tags `slopcop/vX.Y.Z` |
| t3sidebar | SawyerHood/bb-plugin-t3sidebar | sawyer-plugins, `plugins/t3sidebar`, tags `t3sidebar/vX.Y.Z` |

Semver ranges are unchanged. The monorepo carries each plugin's full history via `git subtree`, is MIT licensed, and has release tags for every current version (`cascade/v0.1.0`, `compact-nav/v0.1.0`, `miku/v0.6.0`, `slopcop/v0.1.5`, `t3sidebar/v0.1.0`). SlopCop 0.1.5 is the same code as the previous main branch with runtime dependencies declared correctly.

Author and entry names are unchanged. I am the `author.github` owner of all five entries.

## Test plan

- [x] `node scripts/build.mjs --liveness` passes locally with the new sources
- [ ] CI validates the entries and remote tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)
