### PR TITLE
Update Project Colors to v0.1.3

### DIFF
--- a/entries/project-colors.json
+++ b/entries/project-colors.json
@@ -23,7 +23,7 @@
   "source": {
     "git": {
       "url": "https://github.com/ninjasweb/bb-project-colors.git",
-      "range": "^0.1.1"
+      "range": "^0.1.3"
     }
   },
   "overview": "./overview/project-colors.md"


### PR DESCRIPTION
## What this updates

Moves the Project Colors Git source floor from `^0.1.1` to `^0.1.3`, the current public release. Version 0.1.3 adds compact Codex and Claude provider marks before project thread titles, using Claude orange and theme-aware black/white for Codex.

## Source and release

- Repository: https://github.com/ninjasweb/bb-project-colors
- Git range: `^0.1.3`
- Verified release: `v0.1.3`
- Release commit: `72ff492dbf96b1d00cc025626d71da3ec0c7715e`

## Scope

Only `entries/project-colors.json` changes. The existing icon, screenshot, overview, category, author, permissions, and source repository remain unchanged.

## Validation

Plugin repository:

- `bb plugin types --check` — passed; SDK `0.4.47` matches the host
- `npm test` — passed (7 tests)
- `npm run typecheck` — passed
- `npm run build` — passed

Marketplace repository:

- `npm run build` — passed (170 entries)
- `npm run check` — passed, including source liveness
- `npm test` — 34/35 passed; the single failure is the existing environment-specific Git UTC formatting mismatch in `a later entry edit does not change its first addition date` (`+00:00` versus `Z`) and is unrelated to this entry
- `npm run gate:v1` — correctly requests the `v1-change` label because the Git range is part of the frozen v1 projection

## Permissions and privacy

No permissions or privacy behavior changes. Project Colors stores selections in client-local storage and uses no external service, account, API key, or network request.
