### PR TITLE
Fix root directory path resolution in scripts/build-stats.mjs

### DIFF
--- a/scripts/build-stats.mjs
+++ b/scripts/build-stats.mjs
@@ -17,8 +17,9 @@
 // `--print` writes the document to stdout instead of dist/stats.json.
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const root = new URL("..", import.meta.url).pathname;
+const root = fileURLToPath(new URL("..", import.meta.url));
 const printOnly = process.argv.includes("--print");
 
 /** Same id shape the marketplace schema requires of an entry. */


### PR DESCRIPTION
Resolves #255

### Description
In `scripts/build-stats.mjs`, `root` was resolved using `new URL("..", import.meta.url).pathname`. On Windows, `.pathname` adds a leading slash before the drive letter (`/C:/...`), and on Unix it retains percent-encoding for paths with spaces (`%20`).

This change switches to `fileURLToPath(new URL("..", import.meta.url))`, matching the implementation in `scripts/build.mjs` and `scripts/check-v1-gate.mjs`.

### Local Validation
- [x] `npm run build`
- [x] `npm test`
- [x] `npm run gate:v1`