### PR TITLE
bb-agent-toolbox: widen semver range to ^0.2.0

### DIFF
--- a/entries/bb-agent-toolbox.json
+++ b/entries/bb-agent-toolbox.json
@@ -23,7 +23,7 @@
   "source": {
     "git": {
       "url": "https://github.com/rawizhere/bb-plugin-bb-agent-toolbox.git",
-      "range": "^0.1.0"
+      "range": "^0.2.0"
     }
   }
 }


### PR DESCRIPTION
The catalog range for this entry is `^0.1.0`, which on 0.x caps at `<0.2.0` — installs resolve to `v0.1.1` and miss everything after.

The plugin is on the 0.2.x line now (latest tag `v0.2.2`), so raise the range to `^0.2.0`. Patch releases will stay within 0.2.x, no further range changes expected.

Intentional change to a published v1 entry — needs the `v1-change` label.

`npm run build` and `npm run check` pass locally.