### PR TITLE
worktree-ports: credit by GitHub handle

### DIFF
--- a/entries/worktree-ports.json
+++ b/entries/worktree-ports.json
@@ -14,7 +14,7 @@
     "lsof"
   ],
   "author": {
-    "name": "Russell Biggers",
+    "name": "xlightxyearx",
     "github": "xlightxyearx",
     "url": "https://github.com/xlightxyearx"
   },


### PR DESCRIPTION
Author name for the Worktree Ports entry becomes the GitHub handle. No other changes; build and tests pass.