### PR TITLE
Add unit test coverage for pluginsFromRows in scripts/build-stats.mjs

### DIFF
--- a/scripts/build-stats.mjs
+++ b/scripts/build-stats.mjs
@@ -17,12 +17,10 @@
 // `--print` writes the document to stdout instead of dist/stats.json.
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { pluginsFromRows } from "./marketplace-lib.mjs";
 
 const root = new URL("..", import.meta.url).pathname;
 const printOnly = process.argv.includes("--print");
-
-/** Same id shape the marketplace schema requires of an entry. */
-const ENTRY_ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 
 /** A hostile or broken answer must not become a 100 MB sidecar. */
 const MAX_ENTRIES = 5_000;
@@ -90,36 +88,6 @@ async function queryInstallCounts() {
     throw new Error("PostHog answer has no results array");
   }
   return body.results;
-}
-
-/** Rows PostHog returns are `[plugin_id, installs]`; drop anything else. */
-function pluginsFromRows(rows) {
-  const plugins = {};
-  let dropped = 0;
-  for (const row of rows) {
-    const [id, installs] = Array.isArray(row) ? row : [];
-    if (
-      typeof id !== "string" ||
-      !ENTRY_ID_PATTERN.test(id) ||
-      typeof installs !== "number" ||
-      !Number.isSafeInteger(installs) ||
-      installs < 0
-    ) {
-      dropped += 1;
-      continue;
-    }
-    plugins[id] = { installs };
-  }
-  if (dropped > 0) {
-    console.error(`warning: dropped ${dropped} unusable row(s) from PostHog`);
-  }
-  // Sorted keys keep the published document byte-stable between runs that
-  // return the same counts, so an unchanged sidecar keeps its ETag.
-  return Object.fromEntries(
-    Object.keys(plugins)
-      .sort()
-      .map((id) => [id, plugins[id]]),
-  );
 }
 
 let rows;

--- a/scripts/marketplace-lib.mjs
+++ b/scripts/marketplace-lib.mjs
@@ -25,6 +25,7 @@ export const V1_TOP_LEVEL_FIELDS = Object.freeze([
 export const SCREENSHOT_MAX_BYTES = 2 * 1024 * 1024;
 export const SCREENSHOT_MIN_WIDTH = 1200;
 export const OVERVIEW_MAX_CHARS = 4000;
+export const ENTRY_ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 
 const MARKETPLACE_ORIGIN = "https://getbb.app";
 const SCREENSHOT_FILE_PATTERN =
@@ -727,5 +728,34 @@ export function fillEmptyCollections(collections, plugins) {
     Array.isArray(collection.pluginIds) && collection.pluginIds.length === 0
       ? { ...collection, pluginIds: fallbackIds }
       : collection,
+  );
+}
+
+export function pluginsFromRows(rows, log = console.error) {
+  const plugins = {};
+  let dropped = 0;
+  for (const row of rows ?? []) {
+    const [id, installs] = Array.isArray(row) ? row : [];
+    if (
+      typeof id !== "string" ||
+      !ENTRY_ID_PATTERN.test(id) ||
+      typeof installs !== "number" ||
+      !Number.isSafeInteger(installs) ||
+      installs < 0
+    ) {
+      dropped += 1;
+      continue;
+    }
+    plugins[id] = { installs };
+  }
+  if (dropped > 0 && typeof log === "function") {
+    log(`warning: dropped ${dropped} unusable row(s) from PostHog`);
+  }
+  // Sorted keys keep the published document byte-stable between runs that
+  // return the same counts, so an unchanged sidecar keeps its ETag.
+  return Object.fromEntries(
+    Object.keys(plugins)
+      .sort()
+      .map((id) => [id, plugins[id]]),
   );
 }

--- a/test/marketplace.test.mjs
+++ b/test/marketplace.test.mjs
@@ -31,6 +31,7 @@ import {
   validateAndRewriteIcon,
   validateScreenshotReference,
   v1GateDisposition,
+  pluginsFromRows,
 } from "../scripts/marketplace-lib.mjs";
 
 const testRoot = dirname(fileURLToPath(import.meta.url));
@@ -614,4 +615,48 @@ test("the overview check finds an unreferenced file", () => {
     const orphans = findOrphanOverviewFiles(root, new Set(["overview/used.md"]));
     assert.deepEqual(orphans, ["overview/orphan.md"]);
   });
+});
+
+test("pluginsFromRows accepts valid rows and preserves lexicographical sort", () => {
+  const input = [
+    ["zebra-plugin", 15],
+    ["alpha-plugin", 42],
+    ["beta-tool", 0],
+  ];
+  const result = pluginsFromRows(input, () => {});
+  assert.deepEqual(Object.keys(result), [
+    "alpha-plugin",
+    "beta-tool",
+    "zebra-plugin",
+  ]);
+  assert.deepEqual(result, {
+    "alpha-plugin": { installs: 42 },
+    "beta-tool": { installs: 0 },
+    "zebra-plugin": { installs: 15 },
+  });
+});
+
+test("pluginsFromRows drops malformed rows, invalid IDs, and non-integer counts", () => {
+  const warnings = [];
+  const input = [
+    ["valid-plugin", 100],
+    null,
+    "not-an-array",
+    [],
+    ["ValidPlugin", 10],
+    ["-invalid-leading-dash", 5],
+    ["invalid_underscore", 5],
+    ["plugin-a", -1],
+    ["plugin-b", 3.14],
+    ["plugin-c", "100"],
+    ["plugin-d", Number.NaN],
+    ["plugin-e", Number.POSITIVE_INFINITY],
+    ["plugin-f", Number.MAX_SAFE_INTEGER + 1],
+  ];
+  const result = pluginsFromRows(input, (msg) => warnings.push(msg));
+  assert.deepEqual(result, {
+    "valid-plugin": { installs: 100 },
+  });
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /dropped 12 unusable row\(s\)/);
 });


### PR DESCRIPTION
Resolves #271

### Description
In `scripts/build-stats.mjs`, `pluginsFromRows` is responsible for parsing raw query results from PostHog, validating plugin IDs, dropping corrupt or invalid rows, and sorting keys to ensure byte-stable JSON generation for HTTP caching.

However, `build-stats.mjs` lacked automated unit test coverage because its row-parsing logic was defined inline and top-level network queries were evaluated immediately upon loading.

This PR:
1. Exports `ENTRY_ID_PATTERN` and `pluginsFromRows` from `scripts/marketplace-lib.mjs` (with an optional logger parameter so tests can suppress or assert warning logs cleanly).
2. Imports `pluginsFromRows` in `scripts/build-stats.mjs`.
3. Adds unit test coverage in `test/marketplace.test.mjs` testing:
   - Successful parsing of valid rows and preservation of lexicographical key ordering.
   - Dropping malformed rows, non-array rows, uppercase/invalid plugin IDs, non-safe integers, floats, negative install numbers, and non-numeric values.

### Local Validation
- [x] `npm test` (all 37 tests pass)
- [x] `npm run build`
- [x] `npm run gate:v1`